### PR TITLE
Support python3, parallelization, derived fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
 *.o
 *.pyc
-libyt.so.1.0.0
+libyt.so.1.*
 example/example
-.idea/
-*.png
-lib/*
-stderr
-stdout
-.BAK/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM cindytsai/eureka:python3.8
-
-MAINTAINER cindytsai turquoisea.tsai@gmail.com
-
-COPY . /work1/cindytsai/Project/libyt
-
-

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -351,7 +351,7 @@ int main( int argc, char *argv[] )
 
 
 //    free resources
-      for (int g=0; g<num_grids; g++)  delete [] libyt_grids[g].field_data;
+      // for (int g=0; g<num_grids; g++)  delete [] libyt_grids[g].field_data;
       delete [] libyt_grids;
 
       time += dt;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -115,6 +115,13 @@ int main( int argc, char *argv[] )
       param_yt.frontend                = "gamer";           // simulation frontend
 //    param_yt.fig_basename            = "fig_basename";    // figure base name (default=Fig%09d)
 
+      if (step < total_steps / 2){
+         param_yt.inline_function_name = "yt_inline_ProjectionPlot";
+      }
+      else {
+         param_yt.inline_function_name = "yt_inline_ProfilePlot";
+      }
+
       param_yt.length_unit             = 3.0857e21;         // units are in cgs
       param_yt.mass_unit               = 1.9885e33;
       param_yt.time_unit               = 3.1557e13;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -345,8 +345,8 @@ int main( int argc, char *argv[] )
       }
 
 //    *** libyt API ***
-      if ( yt_add_grids() != YT_SUCCESS ) {
-         fprintf( stderr, "ERROR: yt_add_grids() failed!\n" );
+      if ( yt_commit_grids() != YT_SUCCESS ) {
+         fprintf( stderr, "ERROR: yt_commit_grids() failed!\n" );
          exit( EXIT_FAILURE );
       }
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -98,8 +98,8 @@ int main( int argc, char *argv[] )
    int *grids_MPI = new int [num_grids];                        // Record MPI rank in each grids
 
 // Declare a yt_field array to store field labels and field define type (ex: cell-centered)
-   yt_field  *field_labels = new yt_field [1];                  // field labels {field_name, field_define_type}
-   field_labels[0].field_name = "Dens";
+   yt_field  *field_list = new yt_field [1];                  // field labels {field_name, field_define_type}
+   field_list[0].field_name = "Dens";
 
    double time = 0.0;
 
@@ -126,7 +126,7 @@ int main( int argc, char *argv[] )
       param_yt.refine_by               = REFINE_BY;
       param_yt.num_grids               = num_grids;
       param_yt.num_fields              = num_fields;
-      param_yt.field_labels            = field_labels;
+      param_yt.field_list              = field_list;
       param_yt.field_ftype             = ( typeid(real) == typeid(float) ) ? YT_FLOAT : YT_DOUBLE;
 
       for (int d=0; d<3; d++)

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -115,15 +115,6 @@ int main( int argc, char *argv[] )
       param_yt.frontend                = "gamer";           // simulation frontend
       param_yt.fig_basename            = "FigName";         // figure base name (default=Fig), will append number of calls to libyt
                                                             // at the end
-
-      // execute different inline function in inline python script at different time step
-      if (step < total_steps / 2){
-         param_yt.inline_function_name = "yt_inline_ProjectionPlot";
-      }
-      else {
-         param_yt.inline_function_name = "yt_inline_ProfilePlot";
-      }
-
       param_yt.length_unit             = 3.0857e21;         // units are in cgs
       param_yt.mass_unit               = 1.9885e33;
       param_yt.time_unit               = 3.1557e13;
@@ -204,10 +195,9 @@ int main( int argc, char *argv[] )
       yt_add_user_parameter_double( "user_double3", 3,  user_double3 );
 
 
-//    ==========================================
-//    4. Get pointer to local grids array, 
-//       then set up local grids
-//    ==========================================
+//    ============================================================
+//    4. Get pointer to local grids array, then set up local grids
+//    ============================================================
       yt_grid *grids_local;
       yt_get_gridsPtr( &grids_local );
       
@@ -344,6 +334,9 @@ int main( int argc, char *argv[] )
 
       }
 
+//    ==============================================
+//    5. tell libyt that you have done loading grids
+//    ==============================================
 //    *** libyt API ***
       if ( yt_commit_grids() != YT_SUCCESS ) {
          fprintf( stderr, "ERROR: yt_commit_grids() failed!\n" );
@@ -351,13 +344,29 @@ int main( int argc, char *argv[] )
       }
 
 
-//    ==========================================
-//    5. perform inline analysis
-//    ==========================================
+//    =============================================================
+//    6. perform inline analysis, execute function in python script
+//    =============================================================
 //    *** libyt API ***
-      if ( yt_inline() != YT_SUCCESS )
+      if ( yt_inline( "yt_inline_ProjectionPlot" ) != YT_SUCCESS )
       {
          fprintf( stderr, "ERROR: yt_inline() failed!\n" );
+         exit( EXIT_FAILURE );
+      }
+
+      if ( yt_inline( "yt_inline_ProfilePlot" ) != YT_SUCCESS )
+      {
+         fprintf( stderr, "ERROR: yt_inline() failed!\n" );
+         exit( EXIT_FAILURE );
+      }
+
+//    =============================================================================
+//    7. free grid info loaded into python, end of the inline-analysis at this step
+//    =============================================================================
+//    *** libyt API ***
+      if ( yt_free_gridsPtr() != YT_SUCCESS )
+      {
+         fprintf( stderr, "ERROR: yt_free_gridsPtr() failed!\n" );
          exit( EXIT_FAILURE );
       }
 
@@ -370,7 +379,7 @@ int main( int argc, char *argv[] )
    } // for (int step=0; step<total_steps; step++)
 
 // ==========================================
-// 6. exit libyt
+// 8. exit libyt
 // ==========================================
 // *** libyt API ***
    if ( yt_finalize() != YT_SUCCESS )
@@ -424,4 +433,4 @@ void get_randArray(int *array, int length) {
    for (int i = 0; i < length; i = i+1){
       array[i] = rand() % NRank;
    }
-}
+} // FUNCTION : get_randArray

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -100,6 +100,9 @@ int main( int argc, char *argv[] )
 // Declare a yt_field array to store field labels and field define type (ex: cell-centered)
    yt_field  *field_list = new yt_field [1];                  // field labels {field_name, field_define_type}
    field_list[0].field_name = "Dens";
+   char *field_name_alias[] = {"Name Alias 1", "Name Alias 2", "Name Alias 3"};
+   field_list[0].field_name_alias = field_name_alias;
+   field_list[0].num_field_name_alias = 3;
 
    double time = 0.0;
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -97,8 +97,8 @@ int main( int argc, char *argv[] )
    
    int *grids_MPI = new int [num_grids];                        // Record MPI rank in each grids
 
-// Declare a yt_field array to store field labels and field type (ex: cell-centered)
-   yt_field  *field_labels = new yt_field [1];                  // field labels {field_name, field_type}
+// Declare a yt_field array to store field labels and field define type (ex: cell-centered)
+   yt_field  *field_labels = new yt_field [1];                  // field labels {field_name, field_define_type}
    field_labels[0].field_name = "Dens";
 
    double time = 0.0;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -9,7 +9,7 @@ yt python package with OpenMPI.
         then distribute them to grids_local, to simulate the working process.
 
 And also, to illustrates the basic usage of libyt.
-In steps 0 - 6.
+In steps 0 - 8.
  */
 
 #include <stdlib.h>
@@ -361,7 +361,7 @@ int main( int argc, char *argv[] )
       }
 
 //    =============================================================================
-//    7. free grid info loaded into python, end of the inline-analysis at this step
+//    7. end of the inline-analysis at this step, free grid info loaded into python
 //    =============================================================================
 //    *** libyt API ***
       if ( yt_free_gridsPtr() != YT_SUCCESS )

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -200,9 +200,6 @@ int main( int argc, char *argv[] )
 //    We only have one field in this example.
       field_list[0].field_name = "Dens";
       field_list[0].field_define_type = "cell-centered";
-      field_list[0].field_dimension[0] = GRID_DIM;
-      field_list[0].field_dimension[1] = GRID_DIM;
-      field_list[0].field_dimension[2] = GRID_DIM;
       char *field_name_alias[] = {"Name Alias 1", "Name Alias 2", "Name Alias 3"};
       field_list[0].field_name_alias = field_name_alias;
       field_list[0].num_field_name_alias = 3;
@@ -212,9 +209,11 @@ int main( int argc, char *argv[] )
 //    ============================================================
       yt_grid *grids_local;
       yt_get_gridsPtr( &grids_local );
-      
+
+//    ============================================================
 //    Here, we calculate all the grids (libyt_grids) first, 
 //    then distribute them to grids_local, to simulate the working process.
+//    ============================================================
       yt_grid *libyt_grids = new yt_grid [param_yt.num_grids];
 
 //    set level-0 grids
@@ -304,17 +303,17 @@ int main( int argc, char *argv[] )
 //    set general grid attributes and invoke inline analysis
       for (int gid=0; gid<param_yt.num_grids; gid++)
       {
-         libyt_grids[gid].field_data = new void* [num_fields];
+         libyt_grids[gid].field_data = new yt_data [num_fields];
 
          if (grids_MPI[gid] == myrank){
             for (int v=0; v<num_fields; v++){
-               libyt_grids[gid].field_data[v] = field_data[gid][v];
+               libyt_grids[gid].field_data[v].data_ptr = field_data[gid][v];
             }
          }
          else {
             for (int v=0; v<num_fields; v++){
                // if no data, set it as NULL, so we can make sure each rank contains its own grids only
-               libyt_grids[gid].field_data[v] = NULL;
+               libyt_grids[gid].field_data[v].data_ptr = NULL;
             }
          }
 
@@ -338,7 +337,7 @@ int main( int argc, char *argv[] )
             grids_local[index_local].level          = libyt_grids[gid].level;
 
             for (int v = 0; v < param_yt.num_fields; v = v + 1){
-               grids_local[index_local].field_data[v]     = libyt_grids[gid].field_data[v];
+               grids_local[index_local].field_data[v].data_ptr = libyt_grids[gid].field_data[v].data_ptr;
             }
 
             index_local = index_local + 1;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -348,13 +348,13 @@ int main( int argc, char *argv[] )
 //    6. perform inline analysis, execute function in python script
 //    =============================================================
 //    *** libyt API ***
-      if ( yt_inline( "yt_inline_ProjectionPlot", 1, "\'density\'" ) != YT_SUCCESS )
+      if ( yt_inline_argument( "yt_inline_ProjectionPlot", 1, "\'density\'" ) != YT_SUCCESS )
       {
          fprintf( stderr, "ERROR: yt_inline() failed!\n" );
          exit( EXIT_FAILURE );
       }
 
-      if ( yt_inline( "yt_inline_ProfilePlot", 0 ) != YT_SUCCESS )
+      if ( yt_inline( "yt_inline_ProfilePlot" ) != YT_SUCCESS )
       {
          fprintf( stderr, "ERROR: yt_inline() failed!\n" );
          exit( EXIT_FAILURE );

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -113,8 +113,10 @@ int main( int argc, char *argv[] )
       yt_param_yt param_yt;
 
       param_yt.frontend                = "gamer";           // simulation frontend
-//    param_yt.fig_basename            = "fig_basename";    // figure base name (default=Fig%09d)
+      param_yt.fig_basename            = "FigName";         // figure base name (default=Fig), will append number of calls to libyt
+                                                            // at the end
 
+      // execute different inline function in inline python script at different time step
       if (step < total_steps / 2){
          param_yt.inline_function_name = "yt_inline_ProjectionPlot";
       }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -230,7 +230,7 @@ int main( int argc, char *argv[] )
          {
             libyt_grids[gid].left_edge [d] = grid_order[d]*GRID_DIM*dh0;
             libyt_grids[gid].right_edge[d] = libyt_grids[gid].left_edge[d] + GRID_DIM*dh0;
-            libyt_grids[gid].dimensions[d] = GRID_DIM;   // this example assumes cubic grids
+            libyt_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
 
          libyt_grids[gid].particle_count = 0;      // particles are not supported yet
@@ -277,7 +277,7 @@ int main( int argc, char *argv[] )
          {
             libyt_grids[gid].left_edge [d] = libyt_grids[gid_refine].left_edge[d] + grid_order[d]*GRID_DIM*dh1;
             libyt_grids[gid].right_edge[d] = libyt_grids[gid].left_edge[d] + GRID_DIM*dh1;
-            libyt_grids[gid].dimensions[d] = GRID_DIM;   // this example assumes cubic grids
+            libyt_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
 
          libyt_grids[gid].particle_count = 0;            // particles are not supported yet
@@ -330,7 +330,7 @@ int main( int argc, char *argv[] )
             for (int d = 0; d < 3; d = d+1) {
                grids_local[index_local].left_edge[d]  = libyt_grids[gid].left_edge[d];
                grids_local[index_local].right_edge[d] = libyt_grids[gid].right_edge[d];
-               grids_local[index_local].dimensions[d] = libyt_grids[gid].dimensions[d];
+               grids_local[index_local].grid_dimensions[d] = libyt_grids[gid].grid_dimensions[d];
             }
             grids_local[index_local].particle_count = libyt_grids[gid].particle_count;
             grids_local[index_local].id             = libyt_grids[gid].id;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -351,7 +351,7 @@ int main( int argc, char *argv[] )
 
 
 //    free resources
-      for (int g=0; g<param_yt.num_grids; g++)  delete [] libyt_grids[g].field_data;
+      for (int g=0; g<num_grids; g++)  delete [] libyt_grids[g].field_data;
       delete [] libyt_grids;
 
       time += dt;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -9,7 +9,7 @@ yt python package with OpenMPI.
         then distribute them to grids_local, to simulate the working process.
 
 And also, to illustrates the basic usage of libyt.
-In steps 0 - 8.
+In steps 0 - 9.
  */
 
 #include <stdlib.h>
@@ -97,13 +97,6 @@ int main( int argc, char *argv[] )
    
    int *grids_MPI = new int [num_grids];                        // Record MPI rank in each grids
 
-// Declare a yt_field array to store field labels and field define type (ex: cell-centered)
-   yt_field  *field_list = new yt_field [1];                  // field labels {field_name, field_define_type}
-   field_list[0].field_name = "Dens";
-   char *field_name_alias[] = {"Name Alias 1", "Name Alias 2", "Name Alias 3"};
-   field_list[0].field_name_alias = field_name_alias;
-   field_list[0].num_field_name_alias = 3;
-
    double time = 0.0;
 
 // this array represents the simulation data stored in memory
@@ -129,7 +122,6 @@ int main( int argc, char *argv[] )
       param_yt.refine_by               = REFINE_BY;
       param_yt.num_grids               = num_grids;
       param_yt.num_fields              = num_fields;
-      param_yt.field_list              = field_list;
       param_yt.field_ftype             = ( typeid(real) == typeid(float) ) ? YT_FLOAT : YT_DOUBLE;
 
       for (int d=0; d<3; d++)
@@ -199,9 +191,24 @@ int main( int argc, char *argv[] )
       yt_add_user_parameter_int   ( "user_int3",    3,  user_int3    );
       yt_add_user_parameter_double( "user_double3", 3,  user_double3 );
 
+//    ============================================================
+//    4. Get pointer to field list array, then set up field list
+//    ============================================================
+      yt_field *field_list;
+      yt_get_fieldsPtr( &field_list );
+
+//    We only have one field in this example.
+      field_list[0].field_name = "Dens";
+      field_list[0].field_define_type = "cell-centered";
+      field_list[0].field_dimension[0] = GRID_DIM;
+      field_list[0].field_dimension[1] = GRID_DIM;
+      field_list[0].field_dimension[2] = GRID_DIM;
+      char *field_name_alias[] = {"Name Alias 1", "Name Alias 2", "Name Alias 3"};
+      field_list[0].field_name_alias = field_name_alias;
+      field_list[0].num_field_name_alias = 3;
 
 //    ============================================================
-//    4. Get pointer to local grids array, then set up local grids
+//    5. Get pointer to local grids array, then set up local grids
 //    ============================================================
       yt_grid *grids_local;
       yt_get_gridsPtr( &grids_local );
@@ -340,7 +347,7 @@ int main( int argc, char *argv[] )
       }
 
 //    ==============================================
-//    5. tell libyt that you have done loading grids
+//    6. tell libyt that you have done loading grids
 //    ==============================================
 //    *** libyt API ***
       if ( yt_commit_grids() != YT_SUCCESS ) {
@@ -350,7 +357,7 @@ int main( int argc, char *argv[] )
 
 
 //    =============================================================
-//    6. perform inline analysis, execute function in python script
+//    7. perform inline analysis, execute function in python script
 //    =============================================================
 //    *** libyt API ***
       if ( yt_inline_argument( "yt_inline_ProjectionPlot", 1, "\'density\'" ) != YT_SUCCESS )
@@ -372,7 +379,7 @@ int main( int argc, char *argv[] )
 	  }
 
 //    =============================================================================
-//    7. end of the inline-analysis at this step, free grid info loaded into python
+//    8. end of the inline-analysis at this step, free grid info loaded into python
 //    =============================================================================
 //    *** libyt API ***
       if ( yt_free_gridsPtr() != YT_SUCCESS )
@@ -390,7 +397,7 @@ int main( int argc, char *argv[] )
    } // for (int step=0; step<total_steps; step++)
 
 // ==========================================
-// 8. exit libyt
+// 9. exit libyt
 // ==========================================
 // *** libyt API ***
    if ( yt_finalize() != YT_SUCCESS )

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -360,6 +360,12 @@ int main( int argc, char *argv[] )
          exit( EXIT_FAILURE );
       }
 
+	  if ( yt_inline("test_user_parameter") != YT_SUCCESS )
+	  {
+		 fprintf( stderr, "ERROR: yt_inline() failed!\n" );
+		 exit( EXIT_FAILURE );
+	  }
+
 //    =============================================================================
 //    7. end of the inline-analysis at this step, free grid info loaded into python
 //    =============================================================================

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -348,13 +348,13 @@ int main( int argc, char *argv[] )
 //    6. perform inline analysis, execute function in python script
 //    =============================================================
 //    *** libyt API ***
-      if ( yt_inline( "yt_inline_ProjectionPlot" ) != YT_SUCCESS )
+      if ( yt_inline( "yt_inline_ProjectionPlot", 1, "\'density\'" ) != YT_SUCCESS )
       {
          fprintf( stderr, "ERROR: yt_inline() failed!\n" );
          exit( EXIT_FAILURE );
       }
 
-      if ( yt_inline( "yt_inline_ProfilePlot" ) != YT_SUCCESS )
+      if ( yt_inline( "yt_inline_ProfilePlot", 0 ) != YT_SUCCESS )
       {
          fprintf( stderr, "ERROR: yt_inline() failed!\n" );
          exit( EXIT_FAILURE );

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -97,7 +97,9 @@ int main( int argc, char *argv[] )
    
    int *grids_MPI = new int [num_grids];                        // Record MPI rank in each grids
 
-   const char  *field_labels[num_fields] = { "Dens" };          // field names
+// Declare a yt_field array to store field labels and field type (ex: cell-centered)
+   yt_field  *field_labels = new yt_field [1];                  // field labels {field_name, field_type}
+   field_labels[0].field_name = "Dens";
 
    double time = 0.0;
 
@@ -124,7 +126,7 @@ int main( int argc, char *argv[] )
       param_yt.refine_by               = REFINE_BY;
       param_yt.num_grids               = num_grids;
       param_yt.num_fields              = num_fields;
-      param_yt.field_labels            = (char **)field_labels;
+      param_yt.field_labels            = field_labels;
       param_yt.field_ftype             = ( typeid(real) == typeid(float) ) ? YT_FLOAT : YT_DOUBLE;
 
       for (int d=0; d<3; d++)

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -2,9 +2,9 @@ import yt
 
 yt.enable_parallelism()
 
-def yt_inline_ProjectionPlot():
+def yt_inline_ProjectionPlot( fields ):
     ds = yt.frontends.libyt.libytDataset()
-    prjz = yt.ProjectionPlot(ds, 'z', 'density')
+    prjz = yt.ProjectionPlot(ds, 'z', fields)
 
     if yt.is_root():
         prjz.save()

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -18,4 +18,5 @@ def yt_inline_ProfilePlot():
 
 def test_user_parameter():
     import libyt
+    libyt.method1()
     print("user_int = ", libyt.param_user['user_int'])

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -18,5 +18,4 @@ def yt_inline_ProfilePlot():
 
 def test_user_parameter():
     import libyt
-    libyt.method1()
     print("user_int = ", libyt.param_user['user_int'])

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -16,3 +16,6 @@ def yt_inline_ProfilePlot():
     if yt.is_root():
         profile.save()
 
+def test_user_parameter():
+    import libyt
+    print("user_int = ", libyt.param_user['user_int'])

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -2,7 +2,7 @@ import yt
 
 yt.enable_parallelism()
 
-def yt_inline():
+def yt_inline_ProjectionPlot():
     ds = yt.frontends.libyt.libytDataset()
     # ProjectionPlot, Serial
     ######################################
@@ -10,11 +10,11 @@ def yt_inline():
 
     if yt.is_root():
         prjz.save()
-    # SlicePlot, Serial
-    ######################################
-    #sz = yt.SlicePlot( ds, 'z', 'Dens', center='c' )
-    #sz.set_unit( 'Dens', 'msun/kpc**3' )
-    #sz.set_zlim( 'Dens', 1.0e0, 1.0e6 )
-    #sz.annotate_grids( periodic=False )
-    #sz.save()
+    
+def yt_inline_ProfilePlot():
+    ds = yt.frontends.libyt.libytDataset()
+    profile = yt.ProfilePlot(ds, "x", ["density"])
+
+    if yt.is_root():
+        profile.save()
 

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -4,8 +4,6 @@ yt.enable_parallelism()
 
 def yt_inline_ProjectionPlot():
     ds = yt.frontends.libyt.libytDataset()
-    # ProjectionPlot, Serial
-    ######################################
     prjz = yt.ProjectionPlot(ds, 'z', 'density')
 
     if yt.is_root():

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -1,11 +1,17 @@
 import yt
 
+# Must include this line, if you are running in parallel.
 yt.enable_parallelism()
 
 def yt_inline_ProjectionPlot( fields ):
+    
+    # Load the data, just like using yt.load()
     ds = yt.frontends.libyt.libytDataset()
+    
+    # Do yt operation
     prjz = yt.ProjectionPlot(ds, 'z', fields)
 
+    # Include this line, otherwise yt will save one copy in each rank.
     if yt.is_root():
         prjz.save()
     

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -34,7 +34,8 @@ int yt_add_user_parameter_float ( const char *key, const int n, const float  *in
 int yt_add_user_parameter_double( const char *key, const int n, const double *input );
 int yt_add_user_parameter_string( const char *key,              const char   *input );
 int yt_commit_grids();
-int yt_inline();
+int yt_free_gridsPtr();
+int yt_inline( char *function_name );
 
 #ifdef __cplusplus
 }

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -26,6 +26,7 @@ extern "C" {
 int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt );
 int yt_finalize();
 int yt_set_parameter( yt_param_yt *param_yt );
+int yt_get_fieldsPtr( yt_field **field_list );
 int yt_get_gridsPtr( yt_grid **grids_local );
 int yt_add_user_parameter_int   ( const char *key, const int n, const int    *input );
 int yt_add_user_parameter_long  ( const char *key, const int n, const long   *input );

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -43,7 +43,7 @@ int yt_inline( char *function_name );
 // For derived_func to get grid information by GID and by field_name.
 // These APIs is meant to be used inside user defined derived_func(long GID, double *output)
 int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] );
-int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data );
+int yt_getGridInfo_FieldData( const long gid, const char *field_name, yt_data *field_data);
 
 #ifdef __cplusplus
 }

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -35,7 +35,8 @@ int yt_add_user_parameter_double( const char *key, const int n, const double *in
 int yt_add_user_parameter_string( const char *key,              const char   *input );
 int yt_commit_grids();
 int yt_free_gridsPtr();
-int yt_inline( char *function_name, int argc, ... );
+int yt_inline_argument( char *function_name, int argc, ... );
+int yt_inline( char *function_name );
 
 #ifdef __cplusplus
 }

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -35,12 +35,10 @@ int yt_add_user_parameter_double( const char *key, const int n, const double *in
 int yt_add_user_parameter_string( const char *key,              const char   *input );
 int yt_commit_grids();
 int yt_free_gridsPtr();
-int yt_inline( char *function_name );
+int yt_inline( char *function_name, int argc, ... );
 
 #ifdef __cplusplus
 }
 #endif
-
-
 
 #endif // #ifndef __YT_H__

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -22,6 +22,7 @@
 extern "C" {
 #endif
 
+// For libyt workflow
 int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt );
 int yt_finalize();
 int yt_set_parameter( yt_param_yt *param_yt );
@@ -37,6 +38,11 @@ int yt_commit_grids();
 int yt_free_gridsPtr();
 int yt_inline_argument( char *function_name, int argc, ... );
 int yt_inline( char *function_name );
+
+// For derived_func to get grid information by GID and by field_name.
+// These APIs is meant to be used inside user defined derived_func(long GID, double *output)
+int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] );
+int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data );
 
 #ifdef __cplusplus
 }

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -33,7 +33,7 @@ int yt_add_user_parameter_ulong ( const char *key, const int n, const ulong  *in
 int yt_add_user_parameter_float ( const char *key, const int n, const float  *input );
 int yt_add_user_parameter_double( const char *key, const int n, const double *input );
 int yt_add_user_parameter_string( const char *key,              const char   *input );
-int yt_add_grids();
+int yt_commit_grids();
 int yt_inline();
 
 #ifdef __cplusplus

--- a/include/yt_macro.h
+++ b/include/yt_macro.h
@@ -15,10 +15,10 @@ void log_error( const char *format, ... );
 #define YT_SUCCESS         1
 #define YT_FAIL            0
 
-#define FLT_UNDEFINED      FLT_MAX
-#define DBL_UNDEFINED      DBL_MAX
-#define INT_UNDEFINED      INT_MAX
-#define LNG_UNDEFINED      LONG_MAX
+#define FLT_UNDEFINED      FLT_MIN
+#define DBL_UNDEFINED      DBL_MIN
+#define INT_UNDEFINED      INT_MIN
+#define LNG_UNDEFINED      LONG_MIN
 
 // convenient macro to deal with errors
 #define YT_ABORT( ... )                                              \

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -22,6 +22,8 @@ int  add_dict_scalar( PyObject *dict, const char *key, const T value );
 template <typename T>
 int  add_dict_vector3( PyObject *dict, const char *key, const T *vector );
 int  add_dict_string( PyObject *dict, const char *key, const char *string );
+
+int  add_dict_field_list( );
 #endif
 
 

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -14,9 +14,8 @@ int  create_libyt_module();
 int  init_python( int argc, char *argv[] );
 int  init_libyt_module();
 int  allocate_hierarchy();
-int append_grid( yt_grid *grid );
-int check_hierarchy(yt_hierarchy * &hierarchy);
-int  check_grids();
+int  append_grid( yt_grid *grid );
+int  check_hierarchy(yt_hierarchy * &hierarchy);
 #ifndef NO_PYTHON
 template <typename T>
 int  add_dict_scalar( PyObject *dict, const char *key, const T value );

--- a/include/yt_type.h
+++ b/include/yt_type.h
@@ -24,6 +24,7 @@ enum yt_ftype   { YT_FTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2 };
 #include "yt_type_param_libyt.h"
 #include "yt_type_param_yt.h"
 #include "yt_type_grid.h"
+#include "yt_type_field.h"
 
 //-------------------------------------------------------------------------------------------------------
 // Structure   :  yt_hierarchy

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -31,6 +31,8 @@ void log_warning(const char *Format, ...);
 //                                              (1) "cell-centered"
 //                                              (2) "face-centered"
 //                                              (3) "derived_func"
+//                bool   swap_axes            : true  ==> [z][y][x], x address alter-first, default value.
+//                                              false ==> [x][y][z], z address alter-first
 //                int    field_dimension[3]   : Field dimension, use to pass in array to python.
 //                                              Define as C_array[ fd[0] ][ fd[1] ][ fd[2] ]
 //                char  *field_unit           : Set field_unit if needed.
@@ -52,6 +54,7 @@ struct yt_field
 // ======================================================================================================
 	char  *field_name;
 	char  *field_define_type;
+	bool   swap_axes;
 	int    field_dimension[3];
 	char  *field_unit;
 	int    num_field_name_alias;
@@ -73,6 +76,7 @@ struct yt_field
 	{
 		field_name = NULL;
 		field_define_type = "cell-centered";
+		swap_axes = true;
 		for ( int d=0; d<3; d++ ){
 			field_dimension[d] = INT_UNDEFINED;
 		}

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -9,6 +9,9 @@
 /
 ********************************************************************************/
 
+// include relevant headers/prototypes
+void log_debug( const char *Format, ... );
+
 //-------------------------------------------------------------------------------------------------------
 // Structure   :  yt_field
 // Description :  Data structure to store a field's label and its definition of data representation.
@@ -19,10 +22,55 @@
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
-//                show      : Show the value.
-//                validate  : Check if all data members have been set properly by users
+//                show      : Show the value
 //-------------------------------------------------------------------------------------------------------
 struct yt_field
 {
-	
+// data members
+// ======================================================================================================
+	char *field_name;
+	char *field_type;
+
+//=======================================================================================================
+// Method      : yt_field
+// Description : Constructor of the structure "yt_field"
+// 
+// Note        : 1. Initialize field_type as "cell-centered"
+// 
+// Parameter   : None
+// ======================================================================================================
+	yt_field()
+	{
+		field_name = "NOT SET";
+		field_type = "cell-centered";
+	} // METHOD : yt_field
+
+//=======================================================================================================
+// Method      : ~yt_field
+// Description : Destructor of the structure "yt_field"
+// 
+// Note        : 1. Not used currently
+// 
+// Parameter   : None
+//=======================================================================================================
+	~yt_field()
+	{
+
+	} // METHOD : ~yt_field
+
+//=======================================================================================================
+// Method      : show
+// Description : Print out all data members if the verbose level >= YT_VERBOSE_DEBUG
+// 
+// Note        : 1. Will be used in yt_type_param_yt.h (struct yt_param_yt show())
+// 
+// Parameter   : None
+// 
+// Return      : YT_SUCCESS
+//=======================================================================================================
+	int show() const
+	{
+		log_debug("(%s, %s)", field_name, field_type);
+	}
+
 };

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -9,9 +9,6 @@
 /
 ********************************************************************************/
 
-// include relevant headers/prototypes
-void log_debug( const char *Format, ... );
-
 //-------------------------------------------------------------------------------------------------------
 // Structure   :  yt_field
 // Description :  Data structure to store a field's label and its definition of data representation.

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -24,7 +24,7 @@
 //                int    field_dimension[3]   : Field dimension, use to pass in array to yt, set as default 
 //                                              value if undefined.
 //                char  *field_unit           : Set field_unit if needed.
-//                int    field_name_alias_num : Set fields to alias, number of the aliases.
+//                int    num_field_name_alias : Set fields to alias, number of the aliases.
 //                char **field_name_alias     : Aliases.
 //                char  *field_display_name   : Set display name on the plottings.
 //
@@ -39,7 +39,7 @@ struct yt_field
 	char  *field_define_type;
 	int    field_dimension[3];
 	char  *field_unit;
-	int    field_name_alias_num;
+	int    num_field_name_alias;
 	char **field_name_alias;
 	char  *field_display_name;
 
@@ -60,7 +60,7 @@ struct yt_field
 			field_dimension[d] = INT_UNDEFINED;
 		}
 		field_unit = "NOT SET";
-		field_name_alias_num = 0;
+		num_field_name_alias = 0;
 		field_name_alias = NULL;
 		field_display_name = "NOT SET";
 	} // METHOD : yt_field

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -19,10 +19,7 @@ void log_warning(const char *Format, ...);
 // Description :  Data structure to store a field's label and its definition of data representation.
 // 
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
-//                2. "field_dimension" is used for fields like MHD, they did not have the same dimension
-//                   as in the other field, though they are in the same patch. This is used in 
-//                   append_grid.cpp.
-//                3. "field_unit", "field_name_alias", "field_display_name", are set corresponding to yt 
+//                2. "field_unit", "field_name_alias", "field_display_name", are set corresponding to yt 
 //                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
 //
 // Data Member :  char  *field_name           : Field name
@@ -33,8 +30,6 @@ void log_warning(const char *Format, ...);
 //                                              (3) "derived_func"
 //                bool   swap_axes            : true  ==> [z][y][x], x address alter-first, default value.
 //                                              false ==> [x][y][z], z address alter-first
-//                int    field_dimension[3]   : Field dimension, use to pass in array to python.
-//                                              Define as C_array[ fd[0] ][ fd[1] ][ fd[2] ]
 //                char  *field_unit           : Set field_unit if needed.
 //                int    num_field_name_alias : Set fields to alias, number of the aliases.
 //                char **field_name_alias     : Aliases.
@@ -55,7 +50,6 @@ struct yt_field
 	char  *field_name;
 	char  *field_define_type;
 	bool   swap_axes;
-	int    field_dimension[3];
 	char  *field_unit;
 	int    num_field_name_alias;
 	char **field_name_alias;
@@ -77,9 +71,6 @@ struct yt_field
 		field_name = NULL;
 		field_define_type = "cell-centered";
 		swap_axes = true;
-		for ( int d=0; d<3; d++ ){
-			field_dimension[d] = INT_UNDEFINED;
-		}
 		field_unit = "NOT SET";
 		num_field_name_alias = 0;
 		field_name_alias = NULL;
@@ -107,9 +98,8 @@ struct yt_field
 // Description : Validate data member in the struct.
 // 
 // Note        : 1. Validate data member value in one yt_field struct.
-//                  (0) field_name is set != NULL.
-//                  (1) field_define_type can only be : "cell-centered", "face-centered", "derived_func".
-//                  (2) field_dimension[3] should be greater than 0.
+//                  (1) field_name is set != NULL.
+//                  (2) field_define_type can only be : "cell-centered", "face-centered", "derived_func".
 //                  (3) Raise warning if derived_func == NULL and field_define_type is set to "derived_func".
 //               2. Used in yt_commit_grids()
 // 
@@ -135,14 +125,6 @@ struct yt_field
    	if ( check1 == false ){
    		YT_ABORT("In field [%s], unknown field_define_type [%s]!\n", field_name, field_define_type);
    		return YT_FAIL;
-   	}
-
-   	// field_dimension[3] should be greater than 0.
-   	for ( int i = 0; i < 3; i++ ){
-   		if ( field_dimension[i] <= 0 ){
-   			YT_ABORT("In field [%s], field_dimension[%d] should be greater than 0!\n", field_name, i);
-   			return YT_FAIL;
-   		}
    	}
 
    	// Raise warning if derived_func == NULL and field_define_type is set to "derived_func".

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -28,6 +28,8 @@
 //                char **field_name_alias     : Aliases.
 //                char  *field_display_name   : Set display name on the plottings.
 //
+//                (func pointer) derived_func : pointer to function that has argument int, and double **
+//
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
 //-------------------------------------------------------------------------------------------------------
@@ -42,6 +44,8 @@ struct yt_field
 	int    num_field_name_alias;
 	char **field_name_alias;
 	char  *field_display_name;
+
+	void (*derived_func) (long, double *);
 
 
 //=======================================================================================================
@@ -63,6 +67,8 @@ struct yt_field
 		num_field_name_alias = 0;
 		field_name_alias = NULL;
 		field_display_name = "NOT SET";
+
+		derived_func = NULL;
 	} // METHOD : yt_field
 
 //=======================================================================================================

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -16,13 +16,17 @@
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
 //                2. "field_dimension" is used for fields like MHD, they did not have the same dimension
 //                   as in the other field, though they are in the same patch. This is used in append_grid.cpp.
-//                3. 
+//                3. "field_unit", "field_name_alias", "field_display_name", are set corresponding to yt 
+//                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
 //
-// Data Member :  char *field_name        : Field name
-//                char *field_define_type : Define type, ex: cell-centered
-//                int   field_dimension[3]: Field dimension, use to pass in array to yt, set as default 
-//                                          value if undefined.
-//                char *field_unit        : Set field_unit, 
+// Data Member :  char  *field_name           : Field name
+//                char  *field_define_type    : Define type, ex: cell-centered
+//                int    field_dimension[3]   : Field dimension, use to pass in array to yt, set as default 
+//                                              value if undefined.
+//                char  *field_unit           : Set field_unit if needed.
+//                int    field_name_alias_num : Set fields to alias, number of the aliases.
+//                char **field_name_alias     : Aliases.
+//                char  *field_display_name   : Set display name on the plottings.
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
@@ -31,9 +35,13 @@ struct yt_field
 {
 // data members
 // ======================================================================================================
-	char *field_name;
-	char *field_define_type;
-	int   field_dimension[3];
+	char  *field_name;
+	char  *field_define_type;
+	int    field_dimension[3];
+	char  *field_unit;
+	int    field_name_alias_num;
+	char **field_name_alias;
+	char  *field_display_name;
 
 
 //=======================================================================================================
@@ -51,7 +59,13 @@ struct yt_field
 		for ( int d=0; d<3; d++ ){
 			field_dimension[d] = INT_UNDEFINED;
 		}
+		field_unit = "NOT SET";
+		field_name_alias_num = 0;
+		field_name_alias = NULL;
+		field_display_name = NULL;
 	} // METHOD : yt_field
+
+// TODO: Pretty Print, show the yt_field
 
 //=======================================================================================================
 // Method      : ~yt_field

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -1,0 +1,28 @@
+#ifndef __YT_TYPE_FIELD_H__
+#define __YT_TYPE_FIELD_H__
+
+/*******************************************************************************
+/
+/  yt_field structure
+/
+/  ==> included by yt_type.h
+/
+********************************************************************************/
+
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_field
+// Description :  Data structure to store a field's label and its definition of data representation.
+// 
+// Notes       :  1. The data representation type will be initialize as cell-centered.
+//
+// Data Member :  
+//
+// Method      :  yt_field  : Constructor
+//               ~yt_field  : Destructor
+//                show      : Show the value.
+//                validate  : Check if all data members have been set properly by users
+//-------------------------------------------------------------------------------------------------------
+struct yt_field
+{
+	
+};

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -62,10 +62,23 @@ struct yt_field
 		field_unit = "NOT SET";
 		field_name_alias_num = 0;
 		field_name_alias = NULL;
-		field_display_name = NULL;
+		field_display_name = "NOT SET";
 	} // METHOD : yt_field
 
-// TODO: Pretty Print, show the yt_field
+//=======================================================================================================
+// Method      : show
+// Description : Print out all data members
+// 
+// Note        : 1. Print out "NOT SET" if the pointers are NULL.
+// 
+// Parameter   : None
+// ======================================================================================================
+   int show() const {
+   // TODO: Pretty Print, show the yt_field
+      
+      return YT_SUCCESS;
+   }
+
 
 //=======================================================================================================
 // Method      : ~yt_field

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -14,9 +14,12 @@
 // Description :  Data structure to store a field's label and its definition of data representation.
 // 
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
+//                2. "field_dimension" is used for fields like MHD, they did not have the same dimension
+//                   as in the other field. This is used in append_grid.cpp
 //
 // Data Member :  char *field_name        : Field name
 //                char *field_define_type : Define type, ex: cell-centered
+//                int   field_dimension[3]: Field dimension, use default value if undefined.
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
@@ -27,6 +30,7 @@ struct yt_field
 // ======================================================================================================
 	char *field_name;
 	char *field_define_type;
+	int   field_dimension[3];
 
 //=======================================================================================================
 // Method      : yt_field
@@ -40,6 +44,9 @@ struct yt_field
 	{
 		field_name = "NOT SET";
 		field_define_type = "cell-centered";
+		for ( int d=0; d<3; d++ ){
+			field_dimension[d] = INT_UNDEFINED;
+		}
 	} // METHOD : yt_field
 
 //=======================================================================================================

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -20,7 +20,10 @@
 //                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
 //
 // Data Member :  char  *field_name           : Field name
-//                char  *field_define_type    : Define type, ex: cell-centered
+//                char  *field_define_type    : Define type, for now, we have these types
+//                                              (1) "cell-centered"
+//                                              (2) "face-centered"
+//                                              (3) "derived_func"
 //                int    field_dimension[3]   : Field dimension, use to pass in array to yt, set as default 
 //                                              value if undefined.
 //                char  *field_unit           : Set field_unit if needed.

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -26,7 +26,8 @@ void log_warning(const char *Format, ...);
 //                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
 //
 // Data Member :  char  *field_name           : Field name
-//                char  *field_define_type    : Define type, for now, we have these types
+//                char  *field_define_type    : Define type, for now, we have these types, define in 
+//                                              validate():
 //                                              (1) "cell-centered"
 //                                              (2) "face-centered"
 //                                              (3) "derived_func"
@@ -118,7 +119,7 @@ struct yt_field
    	}
 
    	// field_define_type can only be : "cell-centered", "face-centered", "derived_func".
-   	bool check1 = false;
+   	bool  check1 = false;
    	int   num_type = 3;
    	char *type[3]  = {"cell-centered", "face-centered", "derived_func"};
    	for ( int i = 0; i < num_type; i++ ){

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -22,7 +22,6 @@ void log_debug( const char *Format, ... );
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
-//                show      : Show the value
 //-------------------------------------------------------------------------------------------------------
 struct yt_field
 {
@@ -58,19 +57,6 @@ struct yt_field
 
 	} // METHOD : ~yt_field
 
-//=======================================================================================================
-// Method      : show
-// Description : Print out all data members if the verbose level >= YT_VERBOSE_DEBUG
-// 
-// Note        : 1. Will be used in yt_type_param_yt.h (struct yt_param_yt show())
-// 
-// Parameter   : None
-// 
-// Return      : YT_SUCCESS
-//=======================================================================================================
-	int show() const
-	{
-		log_debug("(%s, %s)", field_name, field_type);
-	}
-
 };
+
+#endif // #ifndef __YT_TYPE_FIELD_H__

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -15,11 +15,14 @@
 // 
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
 //                2. "field_dimension" is used for fields like MHD, they did not have the same dimension
-//                   as in the other field. This is used in append_grid.cpp
+//                   as in the other field, though they are in the same patch. This is used in append_grid.cpp.
+//                3. 
 //
 // Data Member :  char *field_name        : Field name
 //                char *field_define_type : Define type, ex: cell-centered
-//                int   field_dimension[3]: Field dimension, use default value if undefined.
+//                int   field_dimension[3]: Field dimension, use to pass in array to yt, set as default 
+//                                          value if undefined.
+//                char *field_unit        : Set field_unit, 
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
@@ -31,6 +34,7 @@ struct yt_field
 	char *field_name;
 	char *field_define_type;
 	int   field_dimension[3];
+
 
 //=======================================================================================================
 // Method      : yt_field

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -16,9 +16,10 @@ void log_debug( const char *Format, ... );
 // Structure   :  yt_field
 // Description :  Data structure to store a field's label and its definition of data representation.
 // 
-// Notes       :  1. The data representation type will be initialize as cell-centered.
+// Notes       :  1. The data representation type will be initialize as "cell-centered".
 //
-// Data Member :  
+// Data Member :  char *field_name        : Field name
+//                char *field_define_type : Define type, ex: cell-centered
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
@@ -28,20 +29,20 @@ struct yt_field
 // data members
 // ======================================================================================================
 	char *field_name;
-	char *field_type;
+	char *field_define_type;
 
 //=======================================================================================================
 // Method      : yt_field
 // Description : Constructor of the structure "yt_field"
 // 
-// Note        : 1. Initialize field_type as "cell-centered"
+// Note        : 1. Initialize field_define_type as "cell-centered"
 // 
 // Parameter   : None
 // ======================================================================================================
 	yt_field()
 	{
 		field_name = "NOT SET";
-		field_type = "cell-centered";
+		field_define_type = "cell-centered";
 	} // METHOD : yt_field
 
 //=======================================================================================================

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -20,7 +20,8 @@ void log_warning(const char *Format, ...);
 // 
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
 //                2. "field_dimension" is used for fields like MHD, they did not have the same dimension
-//                   as in the other field, though they are in the same patch. This is used in append_grid.cpp.
+//                   as in the other field, though they are in the same patch. This is used in 
+//                   append_grid.cpp.
 //                3. "field_unit", "field_name_alias", "field_display_name", are set corresponding to yt 
 //                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
 //
@@ -29,12 +30,13 @@ void log_warning(const char *Format, ...);
 //                                              (1) "cell-centered"
 //                                              (2) "face-centered"
 //                                              (3) "derived_func"
-//                int    field_dimension[3]   : Field dimension, use to pass in array to yt, set as default 
-//                                              value if undefined.
+//                int    field_dimension[3]   : Field dimension, use to pass in array to python.
+//                                              Define as C_array[ fd[0] ][ fd[1] ][ fd[2] ]
 //                char  *field_unit           : Set field_unit if needed.
 //                int    num_field_name_alias : Set fields to alias, number of the aliases.
 //                char **field_name_alias     : Aliases.
-//                char  *field_display_name   : Set display name on the plottings.
+//                char  *field_display_name   : Set display name on the plottings, if not set, yt will 
+//                                              use field_name as display name.
 //
 //                (func pointer) derived_func : pointer to function that has argument (int, double *)
 //
@@ -76,7 +78,7 @@ struct yt_field
 		field_unit = "NOT SET";
 		num_field_name_alias = 0;
 		field_name_alias = NULL;
-		field_display_name = "NOT SET";
+		field_display_name = NULL;
 
 		derived_func = NULL;
 	} // METHOD : yt_field

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -103,7 +103,7 @@ struct yt_grid
    //
    // Note        :  1. This function does not perform checks that depend on the input
    //                   YT parameters (e.g., whether left_edge lies within the simulation domain)
-   //                   ==> These checks are performed in yt_add_grids()
+   //                   ==> These checks are performed in yt_commit_grids()
    //
    // Parameter   :  None
    //

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -87,7 +87,7 @@ struct yt_grid
    //
    // Note        :  1. Not used currently
    //                2. We do not free the pointer arrays "field_labels" and "field_data" here
-   //                   ==> They must be free'd by users
+   //                   ==> They are freed by yt_free_gridsPtr
    //
    // Parameter   :  None
    //===================================================================================

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -18,7 +18,7 @@
 // 
 // Notes       :  1. We assume that each element in array_name[3] are all in use.
 //
-// Data Member :  dimensions     : Number of cells along each direction
+// Data Member :  dimensions     : Number of cells along each direction in [x][y][z] coordinate.
 //                left_edge      : Grid left  edge in code units
 //                right_edge     : Grid right edge in code units
 //                particle_count : Nunber of particles in this grid

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -86,7 +86,7 @@ struct yt_grid
    // Description :  Destructor of the structure "yt_grid"
    //
    // Note        :  1. Not used currently
-   //                2. We do not free the pointer arrays "field_labels" and "field_data" here
+   //                2. We do not free the pointer arrays "field_list" and "field_data" here
    //                   ==> They are freed by yt_free_gridsPtr
    //
    // Parameter   :  None

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -18,7 +18,7 @@
 // 
 // Notes       :  1. We assume that each element in array_name[3] are all in use.
 //
-// Data Member :  dimensions     : Number of cells along each direction in [x][y][z] coordinate.
+// Data Member :  grid_dimensions: Number of cells along each direction in [x][y][z] coordinate.
 //                left_edge      : Grid left  edge in code units
 //                right_edge     : Grid right edge in code units
 //                particle_count : Nunber of particles in this grid
@@ -44,7 +44,7 @@ struct yt_grid
    long   id;
    long   parent_id;
 
-   int    dimensions[3];
+   int    grid_dimensions[3];
    int    level;
    int    proc_num;
 
@@ -67,7 +67,7 @@ struct yt_grid
       right_edge[d]  = DBL_UNDEFINED; }
 
       for (int d=0; d<3; d++) {
-      dimensions[d]  = INT_UNDEFINED; }
+      grid_dimensions[d]  = INT_UNDEFINED; }
 
       particle_count = LNG_UNDEFINED;
       id             = LNG_UNDEFINED;
@@ -117,7 +117,7 @@ struct yt_grid
       if ( right_edge[d]  == DBL_UNDEFINED    )   YT_ABORT( "\"%s[%d]\" has not been set for grid id [%ld]!\n", "right_edge", d,  id ); }
 
       for (int d=0; d<3; d++) {
-      if ( dimensions[d]  == INT_UNDEFINED    )   YT_ABORT( "\"%s[%d]\" has not been set for grid id [%ld]!\n", "dimensions", d,  id ); }
+      if ( grid_dimensions[d]  == INT_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set for grid id [%ld]!\n", "grid_dimensions", d,  id ); }
       if ( particle_count == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "particle_count", id );
       if ( id             == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "id",             id );
       if ( parent_id      == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "parent_id",      id );
@@ -127,7 +127,7 @@ struct yt_grid
 
 //    additional checks
       for (int d=0; d<3; d++) {
-      if ( dimensions[d] <= 0 )   YT_ABORT( "\"%s[%d]\" == %d <= 0 for grid [%ld]!\n", "dimensions", d, dimensions[d], id ); }
+      if ( grid_dimensions[d] <= 0 )   YT_ABORT( "\"%s[%d]\" == %d <= 0 for grid [%ld]!\n", "grid_dimensions", d, grid_dimensions[d], id ); }
       if ( particle_count < 0 )   YT_ABORT( "\"%s\" == %d < 0 for grid [%ld]!\n", "particle_count", particle_count, id );
       if ( id < 0 )               YT_ABORT( "\"%s\" == %d < 0!\n", "id", id );
       if ( level < 0 )            YT_ABORT( "\"%s\" == %d < 0 for grid [%ld]!\n", "level", level, id );

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -48,7 +48,7 @@ struct yt_grid
    int    level;
    int    proc_num;
 
-   void       **field_data;
+   void   **field_data;
 
    //===================================================================================
    // Method      :  yt_grid

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -11,22 +11,39 @@
 /
 ********************************************************************************/
 
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_data
+// Description :  Data structure to store a field data's pointer and its array dimensions.
+// 
+// Notes       :  1. This struct will be use in yt_grid data member field_data.
+// 
+// Data Member :  data_ptr    : field data pointer
+//                data_dim[3] : dimension of the field data to be passed to python.
+//                              Def => fieldData[ dim[0] ][ dim[1] ][ dim[2] ]
+//-------------------------------------------------------------------------------------------------------
+struct yt_data
+{
+   void *data_ptr;
+   int   data_dim[3];
+};
 
 //-------------------------------------------------------------------------------------------------------
 // Structure   :  yt_grid
 // Description :  Data structure to store a full single grid with data pointer
 // 
-// Notes       :  1. We assume that each element in array_name[3] are all in use.
+// Notes       :  1. We assume that each element in array[3] are all in use, which is we only supports 
+//                   dim 3 for now.
 //
-// Data Member :  grid_dimensions: Number of cells along each direction in [x][y][z] coordinate.
-//                left_edge      : Grid left  edge in code units
-//                right_edge     : Grid right edge in code units
-//                particle_count : Nunber of particles in this grid
-//                level          : AMR level (0 for the root level)
-//                id             : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
-//                parent_id      : Parent grid ID (0-indexed, -1 for grids on the root level)
-//                proc_num       : Process number, grid belong to which MPI rank
-//                field_data     : Pointer arrays pointing to the data of each field
+// Data Member :  grid_dimensions : Number of cells along each direction in [x][y][z] coordinate.
+//                left_edge       : Grid left  edge in code units
+//                right_edge      : Grid right edge in code units
+//                particle_count  : Nunber of particles in this grid
+//                level           : AMR level (0 for the root level)
+//                id              : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
+//                parent_id       : Parent grid ID (0-indexed, -1 for grids on the root level)
+//                proc_num        : Process number, grid belong to which MPI rank
+//                field_data      : Pointer pointing to yt_data array, which stored data pointer 
+//                                  and data dimensions.
 //
 // Method      :  yt_grid  : Constructor
 //               ~yt_grid  : Destructor
@@ -37,18 +54,18 @@ struct yt_grid
 
 // data members
 // ===================================================================================
-   double left_edge[3];
-   double right_edge[3];
+   double    left_edge[3];
+   double    right_edge[3];
 
-   long   particle_count;
-   long   id;
-   long   parent_id;
+   long      particle_count;
+   long      id;
+   long      parent_id;
 
-   int    grid_dimensions[3];
-   int    level;
-   int    proc_num;
+   int       grid_dimensions[3];
+   int       level;
+   int       proc_num;
 
-   void   **field_data;
+   yt_data  *field_data;
 
    //===================================================================================
    // Method      :  yt_grid
@@ -104,6 +121,7 @@ struct yt_grid
    // Note        :  1. This function does not perform checks that depend on the input
    //                   YT parameters (e.g., whether left_edge lies within the simulation domain)
    //                   ==> These checks are performed in yt_commit_grids()
+   //                2. If check needs information other than grid info, we will do it elsewhere.
    //
    // Parameter   :  None
    //

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -25,6 +25,7 @@
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
 //                commit_grids                : true ==> yt_commit_grids() has been called successfully
+//                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, everything is reset.
 //
 // Method      :  yt_param_libyt : Constructor
 //               ~yt_param_libyt : Destructor
@@ -44,6 +45,7 @@ struct yt_param_libyt
    bool  param_yt_set;
    bool  get_gridsPtr;
    bool  commit_grids;
+   bool  free_gridsPtr;
    long  counter;
 
 
@@ -66,6 +68,7 @@ struct yt_param_libyt
       param_yt_set       = false;
       get_gridsPtr       = false;
       commit_grids       = false;
+      free_gridsPtr      = true;
       counter            = 0;
 
    } // METHOD : yt_param_libyt

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -23,6 +23,7 @@
 //                [private] ==> Set and used by libyt internally
 //                libyt_initialized           : true ==> yt_init() has been called successfully
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
+//                get_fieldsPtr               : true ==> yt_get_fieldsPtr() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
 //                commit_grids                : true ==> yt_commit_grids() has been called successfully
 //                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, 
@@ -44,6 +45,7 @@ struct yt_param_libyt
 // ===================================================================================
    bool  libyt_initialized;
    bool  param_yt_set;
+   bool  get_fieldsPtr;
    bool  get_gridsPtr;
    bool  commit_grids;
    bool  free_gridsPtr;
@@ -67,6 +69,7 @@ struct yt_param_libyt
 
       libyt_initialized  = false;
       param_yt_set       = false;
+      get_fieldsPtr      = false;
       get_gridsPtr       = false;
       commit_grids       = false;
       free_gridsPtr      = true;

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -25,7 +25,8 @@
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
 //                commit_grids                : true ==> yt_commit_grids() has been called successfully
-//                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, everything is reset.
+//                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, 
+//                                                       everything is reset and freed.
 //
 // Method      :  yt_param_libyt : Constructor
 //               ~yt_param_libyt : Destructor

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -24,7 +24,7 @@
 //                libyt_initialized           : true ==> yt_init() has been called successfully
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
-//                add_grids                   : true ==> yt_add_grids() has been called successfully
+//                add_grids                   : true ==> yt_commit_grids() has been called successfully
 //
 // Method      :  yt_param_libyt : Constructor
 //               ~yt_param_libyt : Destructor

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -24,7 +24,7 @@
 //                libyt_initialized           : true ==> yt_init() has been called successfully
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
-//                add_grids                   : true ==> yt_commit_grids() has been called successfully
+//                commit_grids                : true ==> yt_commit_grids() has been called successfully
 //
 // Method      :  yt_param_libyt : Constructor
 //               ~yt_param_libyt : Destructor
@@ -43,7 +43,7 @@ struct yt_param_libyt
    bool  libyt_initialized;
    bool  param_yt_set;
    bool  get_gridsPtr;
-   bool  add_grids;
+   bool  commit_grids;
    long  counter;
 
 
@@ -65,7 +65,7 @@ struct yt_param_libyt
       libyt_initialized  = false;
       param_yt_set       = false;
       get_gridsPtr       = false;
-      add_grids          = false;
+      commit_grids       = false;
       counter            = 0;
 
    } // METHOD : yt_param_libyt

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -48,7 +48,7 @@ void log_warning(const char *Format, ...);
 //                num_fields              : Number of fields
 //                grids_MPI               : grids belongs to which MPI rank
 //                num_grids_local         : Number of local grids in each rank
-//                field_labels            : field labels
+//                field_list              : field list, including {field_name, field_define_type}
 //                grids_local             : Ptr to full information of local grids
 //                field_ftype             : Floating-point type of "field_data" ==> YT_FLOAT or YT_DOUBLE
 //
@@ -91,7 +91,7 @@ struct yt_param_yt
    int          num_fields;
    int         *grids_MPI;
    int          num_grids_local;
-   yt_field    *field_labels;
+   yt_field    *field_list;
    yt_ftype     field_ftype;
 
 // Loaded and controlled by libyt
@@ -174,7 +174,7 @@ struct yt_param_yt
       num_fields              = INT_UNDEFINED;
       grids_MPI               = NULL;
       num_grids_local         = INT_UNDEFINED;
-      field_labels            = NULL;
+      field_list              = NULL;
       field_ftype             = YT_FTYPE_UNKNOWN;
 
    // Loaded and controlled by libyt
@@ -223,7 +223,7 @@ struct yt_param_yt
       if ( refine_by               == INT_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "refine_by" );
       if ( num_grids               == LNG_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "num_grids" );
       if ( num_fields              == INT_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "num_fields" );
-      if ( field_labels            == NULL          )   YT_ABORT( "\"%s\" has not been set!\n",     "field_labels");
+      if ( field_list              == NULL          )   YT_ABORT( "\"%s\" has not been set!\n",     "field_list");
       if ( grids_MPI == NULL && num_grids_local == INT_UNDEFINED )  YT_ABORT( "Either grids_MPI or num_grids_local should be set!\n");
       if ( field_ftype != YT_FLOAT  &&  field_ftype != YT_DOUBLE )  YT_ABORT( "Unknown \"%s\" == %d !\n", "field_ftype", field_ftype);
 
@@ -292,9 +292,9 @@ struct yt_param_yt
       log_debug( "   %-*s = %ld\n",        width_scalar, "num_grids_local",         num_grids_local         );
       }
 
-// TODO: Pretty print multiple field_labels
+// TODO: Pretty print multiple field_list
       for (int d=0; d<num_fields; d++) {
-      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_labels", d,    field_labels[d].field_name, field_labels[d].field_define_type); }
+      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_list", d,    field_list[d].field_name, field_list[d].field_define_type); }
 
       return YT_SUCCESS;
 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -292,7 +292,6 @@ struct yt_param_yt
       log_debug( "   %-*s = %ld\n",        width_scalar, "num_grids_local",         num_grids_local         );
       }
 
-// TODO: Pretty print multiple field_list
       for (int d=0; d<num_fields; d++) {
       log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_list", d,    field_list[d].field_name, field_list[d].field_define_type); }
 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -290,8 +290,9 @@ struct yt_param_yt
       log_debug( "   %-*s = %ld\n",        width_scalar, "num_grids_local",         num_grids_local         );
       }
 
+// TODO: Pretty print multiple field_labels
       for (int d=0; d<num_fields; d++) {
-      log_debug("    %-*s[%d] = %s\n",     width_vector, "field_labels", d,         field_labels[d]         ); }
+      log_debug( "   %-*s[%d] = %s\n",     width_vector, "field_labels", d,         field_labels[d]         ); }
 
       return YT_SUCCESS;
 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -27,6 +27,7 @@ void log_debug( const char *Format, ... );
 //
 // Data Member :  frontend                : Name of the target simulation code
 //                fig_basename            : Base name of the output figures
+//                inline_function_name    : Execute inline_script python function name 
 //                domain_left_edge        : Simulation left edge in code units
 //                domain_right_edge       : Simulation right edge in code units
 //                dimensionality          : Dimensionality (1/2/3), this has nothing to do with array.
@@ -62,6 +63,7 @@ struct yt_param_yt
 // ===================================================================================
    const char *frontend;
    const char *fig_basename;
+   const char *inline_function_name;
 
    double domain_left_edge[3];
    double domain_right_edge[3];
@@ -139,8 +141,9 @@ struct yt_param_yt
    {
 
 //    set defaults
-      frontend     = NULL;
-      fig_basename = NULL;
+      frontend      = NULL;
+      fig_basename  = NULL;
+      inline_function_name = NULL;
 
       for (int d=0; d<3; d++)
       {
@@ -196,9 +199,6 @@ struct yt_param_yt
    {
 
       if ( frontend                == NULL          )   YT_ABORT( "\"%s\" has not been set!\n",     "frontend" );
-//    fig_basename will be set to default if it's not set by users
-//    if ( fig_basename            == NULL          )   YT_ABORT( "\"%s\" has not been set!\n",     "fig_basename" );
-
       for (int d=0; d<3; d++) {
       if ( domain_left_edge [d]    == DBL_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set!\n", "domain_left_edge",  d );
       if ( domain_right_edge[d]    == DBL_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set!\n", "domain_right_edge", d ); }
@@ -249,6 +249,7 @@ struct yt_param_yt
 
       log_debug( "   %-*s = %s\n",         width_scalar, "frontend",                frontend                );
       log_debug( "   %-*s = %s\n",         width_scalar, "fig_basename",            fig_basename            );
+      log_debug( "   %-*s = %s\n",         width_scalar, "inline_function_name",    inline_function_name    );
       for (int d=0; d<3; d++) {
       log_debug( "   %-*s[%d] = %13.7e\n", width_vector, "domain_left_edge",  d,    domain_left_edge [d]    ); }
       for (int d=0; d<3; d++) {

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -294,7 +294,7 @@ struct yt_param_yt
 
 // TODO: Pretty print multiple field_labels
       for (int d=0; d<num_fields; d++) {
-      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_labels", d,    field_labels[d].field_name, field_labels[d].field_type); }
+      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_labels", d,    field_labels[d].field_name, field_labels[d].field_define_type); }
 
       return YT_SUCCESS;
 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -293,6 +293,7 @@ struct yt_param_yt
       }
 
       for (int d=0; d<num_fields; d++) {
+      // TODO: Pretty print
       log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_list", d,    field_list[d].field_name, field_list[d].field_define_type); }
 
       return YT_SUCCESS;

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -223,7 +223,6 @@ struct yt_param_yt
       if ( refine_by               == INT_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "refine_by" );
       if ( num_grids               == LNG_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "num_grids" );
       if ( num_fields              == INT_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "num_fields" );
-      if ( field_list              == NULL          )   YT_ABORT( "\"%s\" has not been set!\n",     "field_list");
       if ( grids_MPI == NULL && num_grids_local == INT_UNDEFINED )  YT_ABORT( "Either grids_MPI or num_grids_local should be set!\n");
       if ( field_ftype != YT_FLOAT  &&  field_ftype != YT_DOUBLE )  YT_ABORT( "Unknown \"%s\" == %d !\n", "field_ftype", field_ftype);
 
@@ -291,11 +290,7 @@ struct yt_param_yt
       if (num_grids_local != INT_UNDEFINED){
       log_debug( "   %-*s = %ld\n",        width_scalar, "num_grids_local",         num_grids_local         );
       }
-
-      for (int d=0; d<num_fields; d++) {
-      // TODO: Pretty print
-      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_list", d,    field_list[d].field_name, field_list[d].field_define_type); }
-
+      
       return YT_SUCCESS;
 
    } // METHOD : show

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -27,7 +27,6 @@ void log_debug( const char *Format, ... );
 //
 // Data Member :  frontend                : Name of the target simulation code
 //                fig_basename            : Base name of the output figures
-//                inline_function_name    : Execute inline_script python function name 
 //                domain_left_edge        : Simulation left edge in code units
 //                domain_right_edge       : Simulation right edge in code units
 //                dimensionality          : Dimensionality (1/2/3), this has nothing to do with array.
@@ -63,7 +62,6 @@ struct yt_param_yt
 // ===================================================================================
    const char *frontend;
    const char *fig_basename;
-   const char *inline_function_name;
 
    double domain_left_edge[3];
    double domain_right_edge[3];
@@ -143,7 +141,6 @@ struct yt_param_yt
 //    set defaults
       frontend      = NULL;
       fig_basename  = NULL;
-      inline_function_name = NULL;
 
       for (int d=0; d<3; d++)
       {
@@ -249,7 +246,6 @@ struct yt_param_yt
 
       log_debug( "   %-*s = %s\n",         width_scalar, "frontend",                frontend                );
       log_debug( "   %-*s = %s\n",         width_scalar, "fig_basename",            fig_basename            );
-      log_debug( "   %-*s = %s\n",         width_scalar, "inline_function_name",    inline_function_name    );
       for (int d=0; d<3; d++) {
       log_debug( "   %-*s[%d] = %13.7e\n", width_vector, "domain_left_edge",  d,    domain_left_edge [d]    ); }
       for (int d=0; d<3; d++) {

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -16,7 +16,7 @@
 #include "yt_macro.h"
 #include "yt_type_grid.h"
 void log_debug( const char *Format, ... );
-
+void log_warning(const char *Format, ...);
 
 
 //-------------------------------------------------------------------------------------------------------
@@ -38,9 +38,10 @@ void log_debug( const char *Format, ... );
 //                omega_lambda            : Dark energy mass density
 //                omega_matter            : Dark matter mass density
 //                hubble_constant         : Dimensionless Hubble parameter at the present day
-//                length_unit             : Simulation length unit in CGS
-//                mass_unit               : Simulation mass   unit in CGS
-//                time_unit               : Simulation time   unit in CGS
+//                length_unit             : Simulation length unit in cm (CGS)
+//                mass_unit               : Simulation mass   unit in g  (CGS)
+//                time_unit               : Simulation time   unit in s  (CGS)
+//                magnetic_unit           : Simulation magnetic unit in gauss
 //                refine_by               : Refinement factor between a grid and its subgrid
 //                num_grids               : Total number of grids
 //                num_fields              : Number of fields
@@ -73,6 +74,7 @@ struct yt_param_yt
    double length_unit;
    double mass_unit;
    double time_unit;
+   double magnetic_unit;
 
 // declare all boolean variables as int so that we can check whether they have been set by users
    int    periodicity[3];
@@ -155,6 +157,7 @@ struct yt_param_yt
       length_unit             = DBL_UNDEFINED;
       mass_unit               = DBL_UNDEFINED;
       time_unit               = DBL_UNDEFINED;
+      magnetic_unit           = DBL_UNDEFINED;
 
       for (int d=0; d<3; d++)
       {
@@ -209,7 +212,8 @@ struct yt_param_yt
       if ( length_unit             == DBL_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "length_unit" );
       if ( mass_unit               == DBL_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "mass_unit" );
       if ( time_unit               == DBL_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "time_unit" );
-
+      if ( magnetic_unit           == DBL_UNDEFINED )   log_warning( "\"%s\" has not been set!\n",  "magnetic_unit" );
+      
       for (int d=0; d<3; d++) {
       if ( periodicity      [d]    == INT_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set!\n", "periodicity", d );
       if ( domain_dimensions[d]    == INT_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set!\n", "domain_dimensions", d ); }
@@ -257,9 +261,17 @@ struct yt_param_yt
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "omega_lambda",            omega_lambda            );
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "omega_matter",            omega_matter            );
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "hubble_constant",         hubble_constant         ); }
+
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "length_unit",             length_unit             );
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "mass_unit",               mass_unit               );
       log_debug( "   %-*s = %13.7e\n",     width_scalar, "time_unit",               time_unit               );
+      if ( magnetic_unit == DBL_UNDEFINED ){
+         log_debug( "   %-*s = %s\n",      width_scalar, "magnetic_unit",           "NOT SET"               );
+      }
+      else{
+         log_debug( "   %-*s = %13.7e\n",     width_scalar, "magnetic_unit",        magnetic_unit           );
+      }
+      
       for (int d=0; d<3; d++) {
       log_debug( "   %-*s[%d] = %d\n",     width_vector, "periodicity", d,          periodicity[d]          ); }
       for (int d=0; d<3; d++) {

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -15,6 +15,7 @@
 // include relevant headers/prototypes
 #include "yt_macro.h"
 #include "yt_type_grid.h"
+#include "yt_type_field.h"
 void log_debug( const char *Format, ... );
 void log_warning(const char *Format, ...);
 
@@ -61,6 +62,7 @@ struct yt_param_yt
 
 // data members
 // ===================================================================================
+// variables that will be passed to yt
    const char *frontend;
    const char *fig_basename;
 
@@ -89,7 +91,7 @@ struct yt_param_yt
    int          num_fields;
    int         *grids_MPI;
    int          num_grids_local;
-   char       **field_labels;
+   yt_field    *field_labels;
    yt_ftype     field_ftype;
 
 // Loaded and controlled by libyt
@@ -292,7 +294,7 @@ struct yt_param_yt
 
 // TODO: Pretty print multiple field_labels
       for (int d=0; d<num_fields; d++) {
-      log_debug( "   %-*s[%d] = %s\n",     width_vector, "field_labels", d,         field_labels[d]         ); }
+      log_debug( "   %-*s[%d] = (%s,%s)\n",     width_vector, "field_labels", d,    field_labels[d].field_name, field_labels[d].field_type); }
 
       return YT_SUCCESS;
 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -82,7 +82,7 @@ struct yt_param_yt
    int    refine_by;
    long   num_grids;
 
-// variable for later runtime usage, but will not load into YT
+// variable for later runtime usage
 // Loaded by user
    int          num_fields;
    int         *grids_MPI;

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@
 # source files
 #######################################################################################################
 CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt_add_user_parameter.cpp \
-           yt_commit_grids.cpp yt_get_gridsPtr.cpp
+           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_free_gridsPtr.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
 		   check_hierarchy.cpp append_grid.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@
 # source files
 #######################################################################################################
 CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt_add_user_parameter.cpp \
-           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_free_gridsPtr.cpp
+           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_free_gridsPtr.cpp yt_getGridInfo.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
 		   check_hierarchy.cpp append_grid.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,10 +25,7 @@ LIB_SONAME   := libyt.so.1
 
 # different paths
 #######################################################################################################
-#PYTHON_PATH := /work1/cindytsai/Software/python/python3.8
-#PYTHON_PATH := /projects/ncsa/grav/softwares/miniconda2
-PYTHON_PATH := /home/cindytsai/software/python/python3.8
-#PYTHON_PATH := /home/calab912/software/python/python3.8
+PYTHON_PATH := $(YOUR_PYTHON_PATH)
 OBJ_PATH := ./obj
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@
 # source files
 #######################################################################################################
 CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt_add_user_parameter.cpp \
-           yt_add_grids.cpp yt_get_gridsPtr.cpp
+           yt_commit_grids.cpp yt_get_gridsPtr.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
 		   check_hierarchy.cpp append_grid.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,8 @@
 # source files
 #######################################################################################################
 CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt_add_user_parameter.cpp \
-           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_free_gridsPtr.cpp yt_getGridInfo.cpp
+           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_get_fieldsPtr.cpp yt_free_gridsPtr.cpp            \
+           yt_getGridInfo.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
 		   check_hierarchy.cpp append_grid.cpp
 

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -180,7 +180,7 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 // Description :  Function for adding a dictionary item to a Python dictionary
 //
 // Note        :  1. Add a series of key-value pair to libyt.dict.
-//                2. Used in yt_set_parameter() on loading field_list structure to python.
+//                2. Used in yt_commit_grids() on loading field_list structure to python.
 //                3. PyUnicode_FromString is Python-API >= 3.5, and it returns a new reference.
 //                4. Dictionary structure loaded in python:
 //                   { <field_name>: {"field_define_type" :  <field_define_type>, 

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -195,8 +195,9 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 //-------------------------------------------------------------------------------------------------------
 int add_dict_field_list(){
 
-   PyObject *field_list_dict = PyDict_New();
-   PyObject *field_info_dict = PyDict_New();
+   PyObject  *field_list_dict = PyDict_New();
+   PyObject **field_info_dict = new PyObject* [g_param_yt.num_fields];
+   for (int i = 0; i < g_param_yt.num_fields; i++) { field_info_dict[i] = PyDict_New(); }
    PyObject *key, *val;
 
    key = PyUnicode_FromString("NOT SET");
@@ -204,32 +205,30 @@ int add_dict_field_list(){
 
    for (int i = 0; i < g_param_yt.num_fields; i++){
       // Load "field_define_type", "field_unit", "field_name_alias", "field_display_name" to "field_info_dict".
-      key = PyUnicode_FromString("field_define_type");
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_define_type);
-      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+      if ( PyDict_SetItemString(field_info_dict[i], "field_define_type", val) != 0 ){
          YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_define_type", (g_param_yt.field_list)[i].field_define_type);
       }
 
-      key = PyUnicode_FromString("field_unit");
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_unit);
-      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+      if ( PyDict_SetItemString(field_info_dict[i], "field_unit", val) != 0 ){
          YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_unit", (g_param_yt.field_list)[i].field_unit);
       }
 
       // TODO: Add list to field_name_alias
-      
-      key = PyUnicode_FromString("field_display_name");
+
+
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_display_name);
-      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+      if ( PyDict_SetItemString(field_info_dict[i], "field_display_name", val) != 0 ){
          YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_display_name", (g_param_yt.field_list)[i].field_display_name);
       }
 
       // Load "field_info_dict" to "field_list_dict", with key-value pair {field_name : field_info_dict}
       key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
-      if ( PyDict_SetItem(field_list_dict, key, field_info_dict) != 0 ){
+      if ( PyDict_SetItem(field_list_dict, key, field_info_dict[i]) != 0 ){
          YT_ABORT("On setting dictionary field_list in libyt, field_name [%s] failed to add dictionary!\n", (g_param_yt.field_list)[i].field_name);
       }
 
@@ -245,7 +244,7 @@ int add_dict_field_list(){
    Py_DECREF( key );
    Py_DECREF( val );
    Py_DECREF( field_list_dict );
-   Py_DECREF( field_info_dict );
+   for (int i = 0; i < g_param_yt.num_fields; i++) { Py_DECREF(field_info_dict[i]); }
 
    return YT_SUCCESS;
 }

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -179,37 +179,73 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 // Function    :  add_dict_field_list
 // Description :  Function for adding a dictionary item to a Python dictionary
 //
-// Note        :  1. Add a series of key-value pair to libyt.dict, with key and value both as string.
-//                2. Used in yt_set_parameter() on setting field_list = { field_name: field_define_type}
+// Note        :  1. Add a series of key-value pair to libyt.dict.
+//                2. Used in yt_set_parameter() on loading field_list structure to python.
 //                3. PyUnicode_FromString is Python-API >= 3.5
+//                4. We assume that the num_fields >= 1.
+//                5. Dictionary structure loaded in python:
+//                   { <field_name>: {"field_define_type" :  <field_define_type>, 
+//                                    "field_unit"        :  <field_unit>,
+//                                    "field_name_alias"  : [<field_name_alias>, ],
+//                                    "field_display_name":  <field_display_name>   } }
 //
-// Parameter   :  dict        : Target Python dictionary
-//                field_num   : Number of field
-//                field_list  : yt_field array to be added to dict
+// Parameter   :  None
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
 int add_dict_field_list(){
 
-   PyObject *dict = PyDict_New();
+   PyObject *field_list_dict = PyDict_New();
+   PyObject *field_info_dict = PyDict_New();
    PyObject *key, *val;
 
+   key = PyUnicode_FromString("NOT SET");
+   val = PyUnicode_FromString("NOT SET");
+
    for (int i = 0; i < g_param_yt.num_fields; i++){
-      key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
+      // Load "field_define_type", "field_unit", "field_name_alias", "field_display_name" to "field_info_dict".
+      key = PyUnicode_FromString("field_define_type");
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_define_type);
-      if ( PyDict_SetItem(dict, key, val) != 0 ){
-         YT_ABORT("On setting dictionary field_list in libyt, key-value pair [%s]-[%s] failed!\n", 
-                   (g_param_yt.field_list)[i].field_name, (g_param_yt.field_list)[i].field_define_type);
+      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+                   (g_param_yt.field_list)[i].field_name, "field_define_type", (g_param_yt.field_list)[i].field_define_type);
       }
+
+      key = PyUnicode_FromString("field_unit");
+      val = PyUnicode_FromString((g_param_yt.field_list)[i].field_unit);
+      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+                   (g_param_yt.field_list)[i].field_name, "field_unit", (g_param_yt.field_list)[i].field_unit);
+      }
+
+      // TODO: Add list to field_name_alias
+      
+      key = PyUnicode_FromString("field_display_name");
+      val = PyUnicode_FromString((g_param_yt.field_list)[i].field_display_name);
+      if ( PyDict_SetItem(field_info_dict, key, val) != 0 ){
+         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+                   (g_param_yt.field_list)[i].field_name, "field_display_name", (g_param_yt.field_list)[i].field_display_name);
+      }
+
+      // Load "field_info_dict" to "field_list_dict", with key-value pair {field_name : field_info_dict}
+      key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
+      if ( PyDict_SetItem(field_list_dict, key, field_info_dict) != 0 ){
+         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s] failed to add dictionary!\n", (g_param_yt.field_list)[i].field_name);
+      }
+
+      // TODO: Check if we need this.
+      // Clear the "field_info_dict"
+      // PyDict_Clear( field_info_dict );
    }
 
-   if ( PyDict_SetItemString( g_py_param_yt, "field_list", dict) != 0 ){
+   if ( PyDict_SetItemString( g_py_param_yt, "field_list", field_list_dict) != 0 ){
       YT_ABORT( "Inserting a dictionary field_list item ... failed!\n");
    }
 
    Py_DECREF( key );
    Py_DECREF( val );
-   Py_DECREF( dict );
+   Py_DECREF( field_list_dict );
+   Py_DECREF( field_info_dict );
 
    return YT_SUCCESS;
 }

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -181,9 +181,8 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 //
 // Note        :  1. Add a series of key-value pair to libyt.dict.
 //                2. Used in yt_set_parameter() on loading field_list structure to python.
-//                3. PyUnicode_FromString is Python-API >= 3.5
-//                4. We assume that the num_fields >= 1.
-//                5. Dictionary structure loaded in python:
+//                3. PyUnicode_FromString is Python-API >= 3.5, and it returns a new reference.
+//                4. Dictionary structure loaded in python:
 //                   { <field_name>: {"field_define_type" :  <field_define_type>, 
 //                                    "field_unit"        :  <field_unit>,
 //                                    "field_name_alias"  : [<field_name_alias>, ],
@@ -203,60 +202,62 @@ int add_dict_field_list(){
       field_info_dict[i] = PyDict_New( );
       name_alias_list[i] = PyList_New(0);
    }
-   key = PyUnicode_FromString("");
-   val = PyUnicode_FromString("");
 
    for (int i = 0; i < g_param_yt.num_fields; i++){
+
       // Load "field_define_type", "field_unit", "field_name_alias", "field_display_name" to "field_info_dict".
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_define_type);
       if ( PyDict_SetItemString(field_info_dict[i], "field_define_type", val) != 0 ){
          YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_define_type", (g_param_yt.field_list)[i].field_define_type);
       }
+      Py_DECREF( val );
 
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_unit);
       if ( PyDict_SetItemString(field_info_dict[i], "field_unit", val) != 0 ){
          YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_unit", (g_param_yt.field_list)[i].field_unit);
       }
+      Py_DECREF( val );
 
       for (int j = 0; j < (g_param_yt.field_list)[i].num_field_name_alias; j++){
-         val = PyUnicode_FromString((g_param_yt.field_list)[i].field_name_alias[j]);
+         val = PyUnicode_FromString( (g_param_yt.field_list)[i].field_name_alias[j] );
          if ( PyList_Append(name_alias_list[i], val) != 0 ){
             YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[ list item %s ] failed!\n",
                       (g_param_yt.field_list)[i].field_name, "field_name_alias", (g_param_yt.field_list)[i].field_name_alias[j]);
          }
+         Py_DECREF( val );
       }
-      if( PyDict_SetItemString(field_info_dict[i], "field_name_alias", name_alias_list[i]) != 0 ){
+      if( PyDict_SetItemString( field_info_dict[i], "field_name_alias", name_alias_list[i]) != 0 ){
          YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n",
                    (g_param_yt.field_list)[i].field_name, "field_name_alias", "list of names");
       }
 
 
-      val = PyUnicode_FromString((g_param_yt.field_list)[i].field_display_name);
-      if ( PyDict_SetItemString(field_info_dict[i], "field_display_name", val) != 0 ){
+      val = PyUnicode_FromString( (g_param_yt.field_list)[i].field_display_name );
+      if ( PyDict_SetItemString( field_info_dict[i], "field_display_name", val) != 0 ){
          YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_display_name", (g_param_yt.field_list)[i].field_display_name);
       }
+      Py_DECREF( val );
 
       // Load "field_info_dict" to "field_list_dict", with key-value pair {field_name : field_info_dict}
-      key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
-      if ( PyDict_SetItem(field_list_dict, key, field_info_dict[i]) != 0 ){
+      key = PyUnicode_FromString( (g_param_yt.field_list)[i].field_name );
+      if ( PyDict_SetItem( field_list_dict, key, field_info_dict[i]) != 0 ){
          YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s] failed to add dictionary!\n", (g_param_yt.field_list)[i].field_name);
       }
+      Py_DECREF( key );
 
    }
 
-   if ( PyDict_SetItemString( g_py_param_yt, "field_list", field_list_dict) != 0 ){
+   if ( PyDict_SetItemString( g_py_param_yt, "field_list", field_list_dict ) != 0 ){
       YT_ABORT( "Inserting dictionary [field_list] item to libyt ... failed!\n");
    }
 
-   Py_DECREF( key );
-   Py_DECREF( val );
    Py_DECREF( field_list_dict );
    for (int i = 0; i < g_param_yt.num_fields; i++) {
-      Py_DECREF(field_info_dict[i]);
-      Py_DECREF(name_alias_list[i]);
+      Py_DECREF( field_info_dict[i] );
+      Py_DECREF( name_alias_list[i] );
    }
 
    return YT_SUCCESS;

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -196,55 +196,68 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 int add_dict_field_list(){
 
    PyObject  *field_list_dict = PyDict_New();
+   PyObject  *key, *val;
    PyObject **field_info_dict = new PyObject* [g_param_yt.num_fields];
-   for (int i = 0; i < g_param_yt.num_fields; i++) { field_info_dict[i] = PyDict_New(); }
-   PyObject *key, *val;
-
-   key = PyUnicode_FromString("NOT SET");
-   val = PyUnicode_FromString("NOT SET");
+   PyObject **name_alias_list = new PyObject* [g_param_yt.num_fields];
+   for (int i = 0; i < g_param_yt.num_fields; i++) { 
+      field_info_dict[i] = PyDict_New( );
+      name_alias_list[i] = PyList_New(0);
+   }
+   key = PyUnicode_FromString("");
+   val = PyUnicode_FromString("");
 
    for (int i = 0; i < g_param_yt.num_fields; i++){
       // Load "field_define_type", "field_unit", "field_name_alias", "field_display_name" to "field_info_dict".
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_define_type);
       if ( PyDict_SetItemString(field_info_dict[i], "field_define_type", val) != 0 ){
-         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+         YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_define_type", (g_param_yt.field_list)[i].field_define_type);
       }
 
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_unit);
       if ( PyDict_SetItemString(field_info_dict[i], "field_unit", val) != 0 ){
-         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+         YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_unit", (g_param_yt.field_list)[i].field_unit);
       }
 
-      // TODO: Add list to field_name_alias
+      for (int j = 0; j < (g_param_yt.field_list)[i].num_field_name_alias; j++){
+         val = PyUnicode_FromString((g_param_yt.field_list)[i].field_name_alias[j]);
+         if ( PyList_Append(name_alias_list[i], val) != 0 ){
+            YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[ list item %s ] failed!\n",
+                      (g_param_yt.field_list)[i].field_name, "field_name_alias", (g_param_yt.field_list)[i].field_name_alias[j]);
+         }
+      }
+      if( PyDict_SetItemString(field_info_dict[i], "field_name_alias", name_alias_list[i]) != 0 ){
+         YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n",
+                   (g_param_yt.field_list)[i].field_name, "field_name_alias", "list of names");
+      }
 
 
       val = PyUnicode_FromString((g_param_yt.field_list)[i].field_display_name);
       if ( PyDict_SetItemString(field_info_dict[i], "field_display_name", val) != 0 ){
-         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
+         YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[%s] failed!\n", 
                    (g_param_yt.field_list)[i].field_name, "field_display_name", (g_param_yt.field_list)[i].field_display_name);
       }
 
       // Load "field_info_dict" to "field_list_dict", with key-value pair {field_name : field_info_dict}
       key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
       if ( PyDict_SetItem(field_list_dict, key, field_info_dict[i]) != 0 ){
-         YT_ABORT("On setting dictionary field_list in libyt, field_name [%s] failed to add dictionary!\n", (g_param_yt.field_list)[i].field_name);
+         YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s] failed to add dictionary!\n", (g_param_yt.field_list)[i].field_name);
       }
 
-      // TODO: Check if we need this.
-      // Clear the "field_info_dict"
-      // PyDict_Clear( field_info_dict );
    }
 
    if ( PyDict_SetItemString( g_py_param_yt, "field_list", field_list_dict) != 0 ){
-      YT_ABORT( "Inserting a dictionary field_list item ... failed!\n");
+      YT_ABORT( "Inserting dictionary [field_list] item to libyt ... failed!\n");
    }
 
    Py_DECREF( key );
    Py_DECREF( val );
    Py_DECREF( field_list_dict );
-   for (int i = 0; i < g_param_yt.num_fields; i++) { Py_DECREF(field_info_dict[i]); }
+   for (int i = 0; i < g_param_yt.num_fields; i++) {
+      Py_DECREF(field_info_dict[i]);
+      Py_DECREF(name_alias_list[i]);
+   }
 
    return YT_SUCCESS;
 }

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -188,7 +188,8 @@ template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const 
 //                   { <field_name>: {"field_define_type" :  <field_define_type>, 
 //                                    "field_unit"        :  <field_unit>,
 //                                    "field_name_alias"  : [<field_name_alias>, ],
-//                                    "field_display_name":  <field_display_name>   } }
+//                                    "field_display_name":  <field_display_name> , 
+//                                    "swap_axes"         :  true / false          } }
 //
 // Parameter   :  None
 //
@@ -252,6 +253,20 @@ int add_dict_field_list(){
                       (g_param_yt.field_list)[i].field_name, "field_display_name", (g_param_yt.field_list)[i].field_display_name);
          }
          Py_DECREF( val );
+      }
+
+      // Load "swap_axes" to "field_info_dict".
+      if ( (g_param_yt.field_list)[i].swap_axes == true ){
+         if ( PyDict_SetItemString( field_info_dict[i], "swap_axes", Py_True) != 0 ){
+            YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[ true ] failed!\n", 
+                      (g_param_yt.field_list)[i].field_name, "swap_axes");
+         }
+      } 
+      else {
+         if ( PyDict_SetItemString( field_info_dict[i], "swap_axes", Py_False) != 0 ){
+            YT_ABORT("On setting dictionary [field_list] in libyt, field_name [%s], key-value pair [%s]-[ false ] failed!\n", 
+                      (g_param_yt.field_list)[i].field_name, "swap_axes");
+         }
       }
 
 

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -175,3 +175,41 @@ template int add_dict_vector3 <long  > ( PyObject *dict, const char *key, const 
 template int add_dict_vector3 <uint  > ( PyObject *dict, const char *key, const uint   *vector );
 template int add_dict_vector3 <ulong > ( PyObject *dict, const char *key, const ulong  *vector );
 
+//-------------------------------------------------------------------------------------------------------
+// Function    :  add_dict_field_list
+// Description :  Function for adding a dictionary item to a Python dictionary
+//
+// Note        :  1. Add a series of key-value pair to libyt.dict, with key and value both as string.
+//                2. Used in yt_set_parameter() on setting field_list = { field_name: field_define_type}
+//                3. PyUnicode_FromString is Python-API >= 3.5
+//
+// Parameter   :  dict        : Target Python dictionary
+//                field_num   : Number of field
+//                field_list  : yt_field array to be added to dict
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int add_dict_field_list(){
+
+   PyObject *dict = PyDict_New();
+   PyObject *key, *val;
+
+   for (int i = 0; i < g_param_yt.num_fields; i++){
+      key = PyUnicode_FromString((g_param_yt.field_list)[i].field_name);
+      val = PyUnicode_FromString((g_param_yt.field_list)[i].field_define_type);
+      if ( PyDict_SetItem(dict, key, val) != 0 ){
+         YT_ABORT("On setting dictionary field_list in libyt, key-value pair [%s]-[%s] failed!\n", 
+                   (g_param_yt.field_list)[i].field_name, (g_param_yt.field_list)[i].field_define_type);
+      }
+   }
+
+   if ( PyDict_SetItemString( g_py_param_yt, "field_list", dict) != 0 ){
+      YT_ABORT( "Inserting a dictionary field_list item ... failed!\n");
+   }
+
+   Py_DECREF( key );
+   Py_DECREF( val );
+   Py_DECREF( dict );
+
+   return YT_SUCCESS;
+}

--- a/src/allocate_hierarchy.cpp
+++ b/src/allocate_hierarchy.cpp
@@ -1,7 +1,5 @@
 #include "yt_combo.h"
 
-// TODO: Function name and filename misleading...
-
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  allocate_hierarchy

--- a/src/allocate_hierarchy.cpp
+++ b/src/allocate_hierarchy.cpp
@@ -8,7 +8,7 @@
 // Description :  Fill the libyt.hierarchy dictionary with NumPy arrays allocated but uninitialized
 //
 // Note        :  1. Called by yt_set_parameter(), since it needs param_yt.num_grids, param_yt.num_fields in .
-//                2. These NumPy array will be set when calling yt_add_grids()
+//                2. These NumPy array will be set when calling yt_commit_grids()
 //
 // Parameter   :  None
 //

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -39,26 +39,26 @@ int append_grid( yt_grid *grid ){
    FILL_ARRAY( "proc_num",            &grid->proc_num,       1, npy_int    );
    log_debug( "Inserting grid [%15ld] info to libyt.hierarchy ... done\n", grid->id );
 
-// export grid data to libyt.grid_data as "libyt.grid_data[grid_id][field_label][field_data]"
+// export grid data to libyt.grid_data as "libyt.grid_data[grid_id][field_list.field_name][field_data]"
    int      grid_ftype   = (g_param_yt.field_ftype == YT_FLOAT ) ? NPY_FLOAT : NPY_DOUBLE;
    npy_intp grid_dims[3] = { grid->dimensions[0], grid->dimensions[1], grid->dimensions[2] };
    PyObject *py_grid_id, *py_field_labels, *py_field_data;
 
-// allocate [grid_id][field_label]
+// allocate [grid_id][field_list.field_name]
    py_grid_id      = PyLong_FromLong( grid->id );
    py_field_labels = PyDict_New();
 
    PyDict_SetItem( g_py_grid_data, py_grid_id, py_field_labels );
 
-// fill [grid_id][field_label][field_data]
+// fill [grid_id][field_list.field_name][field_data]
    for (int v=0; v<g_param_yt.num_fields; v++)
    {
 //    PyArray_SimpleNewFromData simply creates an array wrapper and does note allocate and own the array
       py_field_data = PyArray_SimpleNewFromData( 3, grid_dims, grid_ftype, grid->field_data[v] );
 
-//    add the field data to "libyt.grid_data[grid_id][field_label]"
-//    TODO: field_labels is now yt_field struct
-      PyDict_SetItemString( py_field_labels, g_param_yt.field_labels[v].field_name, py_field_data );
+//    add the field data to "libyt.grid_data[grid_id][field_list.field_name]"
+//    TODO: field_list is now yt_field struct
+      PyDict_SetItemString( py_field_labels, g_param_yt.field_list[v].field_name, py_field_data );
 
 //    call decref since PyDict_SetItemString() returns a new reference
       Py_DECREF( py_field_data );
@@ -66,7 +66,7 @@ int append_grid( yt_grid *grid ){
 //    we assume that field data of specific range are not disperse, they contain in one MPI rank only
       if ( grid->field_data[v] != NULL ) {
          log_debug( "Inserting grid [%15ld] field data [%s] to libyt.grid_data ... done\n", 
-                     grid->id, g_param_yt.field_labels[v].field_name );
+                     grid->id, g_param_yt.field_list[v].field_name );
       }
    }
 

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -53,13 +53,10 @@ int append_grid( yt_grid *grid ){
 // fill [grid_id][field_list.field_name][field_data]
    for (int v=0; v<g_param_yt.num_fields; v++)
    {
-//    get the grids dimension, use default (grid->dimension) if field_list.field_dimension not set.
-      npy_intp grid_dims[3] = { grid->dimensions[0], grid->dimensions[1], grid->dimensions[2] };
-      if ( g_param_yt.field_list[v].field_dimension[0] > 0 && g_param_yt.field_list[v].field_dimension[1] > 0 && g_param_yt.field_list[v].field_dimension[2] > 0){
-         grid_dims[0] = g_param_yt.field_list[v].field_dimension[0];
-         grid_dims[1] = g_param_yt.field_list[v].field_dimension[1];
-         grid_dims[2] = g_param_yt.field_list[v].field_dimension[2];
-      }
+//    get the dimension of the input array from field_list.
+      npy_intp grid_dims[3] = { g_param_yt.field_list[v].field_dimension[0], 
+                                g_param_yt.field_list[v].field_dimension[1], 
+                                g_param_yt.field_list[v].field_dimension[2] };
       
 //    PyArray_SimpleNewFromData simply creates an array wrapper and does note allocate and own the array
       py_field_data = PyArray_SimpleNewFromData( 3, grid_dims, grid_ftype, grid->field_data[v] );

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -41,7 +41,7 @@ int append_grid( yt_grid *grid ){
 
 // export grid data to libyt.grid_data as "libyt.grid_data[grid_id][field_list.field_name][field_data]"
    int      grid_ftype   = (g_param_yt.field_ftype == YT_FLOAT ) ? NPY_FLOAT : NPY_DOUBLE;
-   npy_intp grid_dims[3] = { grid->dimensions[0], grid->dimensions[1], grid->dimensions[2] };
+   
    PyObject *py_grid_id, *py_field_labels, *py_field_data;
 
 // allocate [grid_id][field_list.field_name]
@@ -53,6 +53,14 @@ int append_grid( yt_grid *grid ){
 // fill [grid_id][field_list.field_name][field_data]
    for (int v=0; v<g_param_yt.num_fields; v++)
    {
+//    get the grids dimension, use default (grid->dimension) if field_list.field_dimension not set.
+      npy_intp grid_dims[3] = { grid->dimensions[0], grid->dimensions[1], grid->dimensions[2] };
+      if ( g_param_yt.field_list[v].field_dimension[0] > 0 && g_param_yt.field_list[v].field_dimension[1] > 0 && g_param_yt.field_list[v].field_dimension[2] > 0){
+         grid_dims[0] = g_param_yt.field_list[v].field_dimension[0];
+         grid_dims[1] = g_param_yt.field_list[v].field_dimension[1];
+         grid_dims[2] = g_param_yt.field_list[v].field_dimension[2];
+      }
+      
 //    PyArray_SimpleNewFromData simply creates an array wrapper and does note allocate and own the array
       py_field_data = PyArray_SimpleNewFromData( 3, grid_dims, grid_ftype, grid->field_data[v] );
 

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -6,7 +6,7 @@
 // Description :  Add a single full grid to the libyt Python module
 //
 // Note        :  1. Store the input "grid" to libyt.hierarchy and libyt.grid_data to python
-//                2. Called and use by yt_add_grids().
+//                2. Called and use by yt_commit_grids().
 //
 // Parameter   :  yt_grid *grid
 //

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -57,7 +57,8 @@ int append_grid( yt_grid *grid ){
       py_field_data = PyArray_SimpleNewFromData( 3, grid_dims, grid_ftype, grid->field_data[v] );
 
 //    add the field data to "libyt.grid_data[grid_id][field_label]"
-      PyDict_SetItemString( py_field_labels, g_param_yt.field_labels[v], py_field_data );
+//    TODO: field_labels is now yt_field struct
+      PyDict_SetItemString( py_field_labels, g_param_yt.field_labels[v].field_name, py_field_data );
 
 //    call decref since PyDict_SetItemString() returns a new reference
       Py_DECREF( py_field_data );
@@ -65,7 +66,7 @@ int append_grid( yt_grid *grid ){
 //    we assume that field data of specific range are not disperse, they contain in one MPI rank only
       if ( grid->field_data[v] != NULL ) {
          log_debug( "Inserting grid [%15ld] field data [%s] to libyt.grid_data ... done\n", 
-                     grid->id, g_param_yt.field_labels[v] );
+                     grid->id, g_param_yt.field_labels[v].field_name );
       }
    }
 

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -57,7 +57,6 @@ int append_grid( yt_grid *grid ){
       py_field_data = PyArray_SimpleNewFromData( 3, grid_dims, grid_ftype, grid->field_data[v] );
 
 //    add the field data to "libyt.grid_data[grid_id][field_list.field_name]"
-//    TODO: field_list is now yt_field struct
       PyDict_SetItemString( py_field_labels, g_param_yt.field_list[v].field_name, py_field_data );
 
 //    call decref since PyDict_SetItemString() returns a new reference

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -32,7 +32,7 @@ int append_grid( yt_grid *grid ){
 
    FILL_ARRAY( "grid_left_edge",       grid->left_edge,      3, npy_double );
    FILL_ARRAY( "grid_right_edge",      grid->right_edge,     3, npy_double );
-   FILL_ARRAY( "grid_dimensions",      grid->dimensions,     3, npy_long   );
+   FILL_ARRAY( "grid_dimensions",      grid->grid_dimensions,3, npy_long   );
    FILL_ARRAY( "grid_particle_count", &grid->particle_count, 1, npy_long   );
    FILL_ARRAY( "grid_parent_id",      &grid->parent_id,      1, npy_long   );
    FILL_ARRAY( "grid_levels",         &grid->level,          1, npy_long   );

--- a/src/check_hierarchy.cpp
+++ b/src/check_hierarchy.cpp
@@ -33,6 +33,24 @@ int check_hierarchy(yt_hierarchy * &hierarchy) {
         }
     }
 
+    // DEBUG:
+    printf("#FLAG\n");
+    for (int i = 0; i < g_param_yt.num_grids; i = i+1){
+        printf("i = %d\n");
+        printf("id = %ld\n", hierarchy[i].id);
+        printf("parent_id = %ld\n", hierarchy[i].parent_id);
+        printf("level = %d\n", hierarchy[i].level);
+        printf("proc_num = %d\n", hierarchy[i].proc_num);
+        printf("left_edge[0], left_edge[1], left_edge[2] = %lf, %lf, %lf\n", 
+                hierarchy[i].left_edge[0], hierarchy[i].left_edge[1], hierarchy[i].left_edge[2]);
+        printf("right_edge[0], right_edge[1], right_edge[2] = %lf, %lf, %lf\n", 
+                hierarchy[i].right_edge[0], hierarchy[i].right_edge[1], hierarchy[i].right_edge[2]);
+        printf("particle_count = %ld\n", hierarchy[i].particle_count);
+        printf("dimensions[0], dimensions[1], dimensions[2] = %d, %d, %d\n", 
+                hierarchy[i].dimensions[0], hierarchy[i].dimensions[1], hierarchy[i].dimensions[2]);
+        printf("=========================================================\n");
+    }
+
     // Check if all level > 0 have good parent id, and that children's edges don't exceed parent's
     for (long i = 0; i < g_param_yt.num_grids; i = i+1) {
 

--- a/src/check_hierarchy.cpp
+++ b/src/check_hierarchy.cpp
@@ -33,24 +33,6 @@ int check_hierarchy(yt_hierarchy * &hierarchy) {
         }
     }
 
-    // DEBUG:
-    printf("#FLAG\n");
-    for (int i = 0; i < g_param_yt.num_grids; i = i+1){
-        printf("i = %d\n", i);
-        printf("id = %ld\n", hierarchy[i].id);
-        printf("parent_id = %ld\n", hierarchy[i].parent_id);
-        printf("level = %d\n", hierarchy[i].level);
-        printf("proc_num = %d\n", hierarchy[i].proc_num);
-        printf("left_edge[0], left_edge[1], left_edge[2] = %lf, %lf, %lf\n", 
-                hierarchy[i].left_edge[0], hierarchy[i].left_edge[1], hierarchy[i].left_edge[2]);
-        printf("right_edge[0], right_edge[1], right_edge[2] = %lf, %lf, %lf\n", 
-                hierarchy[i].right_edge[0], hierarchy[i].right_edge[1], hierarchy[i].right_edge[2]);
-        printf("particle_count = %ld\n", hierarchy[i].particle_count);
-        printf("dimensions[0], dimensions[1], dimensions[2] = %d, %d, %d\n", 
-                hierarchy[i].dimensions[0], hierarchy[i].dimensions[1], hierarchy[i].dimensions[2]);
-        printf("=========================================================\n");
-    }
-
     // Check if all level > 0 have good parent id, and that children's edges don't exceed parent's
     for (long i = 0; i < g_param_yt.num_grids; i = i+1) {
 

--- a/src/check_hierarchy.cpp
+++ b/src/check_hierarchy.cpp
@@ -6,7 +6,7 @@
 // Function    :  check_hierarchy.cpp
 // Description :  Check that the hierarchy, parent-children relationships are correct
 //
-// Note        :  1. Use inside yt_add_grids()
+// Note        :  1. Use inside yt_commit_grids()
 // 			      2. Check that the hierarchy is correct, even though we didn't build a parent-children 
 //                   map.
 // 				  

--- a/src/check_hierarchy.cpp
+++ b/src/check_hierarchy.cpp
@@ -36,7 +36,7 @@ int check_hierarchy(yt_hierarchy * &hierarchy) {
     // DEBUG:
     printf("#FLAG\n");
     for (int i = 0; i < g_param_yt.num_grids; i = i+1){
-        printf("i = %d\n");
+        printf("i = %d\n", i);
         printf("id = %ld\n", hierarchy[i].id);
         printf("parent_id = %ld\n", hierarchy[i].parent_id);
         printf("level = %d\n", hierarchy[i].level);

--- a/src/check_hierarchy.cpp
+++ b/src/check_hierarchy.cpp
@@ -23,24 +23,24 @@ int check_hierarchy(yt_hierarchy * &hierarchy) {
     }
     
     // Check every grid id are unique, and also filled in the search table
-    for (int i = 0; i < g_param_yt.num_grids; i = i+1) {
+    for (long i = 0; i < g_param_yt.num_grids; i = i+1) {
         if (order[ hierarchy[i].id ] == -1) {
             order[ hierarchy[i].id ] = i;
         }
         else {
-            YT_ABORT("Grid ID [ %d ] are not unique, both MPI rank %d and %d have use this grid id!\n", 
+            YT_ABORT("Grid ID [ %ld ] are not unique, both MPI rank %d and %d are using this grid id!\n", 
                       hierarchy[i].id, hierarchy[i].proc_num, hierarchy[ order[ hierarchy[i].id ] ].proc_num);
         }
     }
 
     // Check if all level > 0 have good parent id, and that children's edges don't exceed parent's
-    for (int i = 0; i < g_param_yt.num_grids; i = i+1) {
+    for (long i = 0; i < g_param_yt.num_grids; i = i+1) {
 
         if ( hierarchy[i].level > 0 ) {
             
             // Check parent id
             if ( (hierarchy[i].parent_id < 0) || hierarchy[i].parent_id >= g_param_yt.num_grids ){
-                YT_ABORT("Grid ID [%ld], Level %d, Parent ID [%ld], expect Parent ID be 0 ~ %d.\n", 
+                YT_ABORT("Grid ID [%ld], Level %d, Parent ID [%ld], expect Parent ID to be 0 ~ %ld.\n", 
                           hierarchy[i].id, hierarchy[i].level, hierarchy[i].parent_id, g_param_yt.num_grids - 1);
             }
             else {

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -37,7 +37,7 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
     char *field_name;
 
     if ( !PyArg_ParseTuple(args, "ls", &gid, &field_name) ){
-        PyErr_SetString(PyExc_ValueError, "Wrong input type, expect to be libyt.derived_func(int, str).");
+        PyErr_SetString(PyExc_TypeError, "Wrong input type, expect to be libyt.derived_func(int, str).");
         return NULL;
     }
 
@@ -54,7 +54,7 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
                 derived_func = g_param_yt.field_list[v].derived_func;
             }
             else {
-                PyErr_Format(PyExc_AttributeError, "In field_list, field_name [ %s ], derived_func does not set properly.\n", 
+                PyErr_Format(PyExc_NotImplementedError, "In field_list, field_name [ %s ], derived_func does not set properly.\n", 
                              g_param_yt.field_list[v].field_name);
                 return NULL;
             }
@@ -63,7 +63,7 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
     }
 
     if ( !have_FieldName ) {
-        PyErr_Format(PyExc_AttributeError, "Cannot find field_name [ %s ] in field_list.\n", field_name);
+        PyErr_Format(PyExc_ValueError, "Cannot find field_name [ %s ] in field_list.\n", field_name);
         return NULL;
     }
 
@@ -86,7 +86,7 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
     if ( !have_Grid ){
         int MyRank;
         MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
-        PyErr_Format(PyExc_AttributeError, "Cannot find grid with GID [ %ld ] on MPI rank [%d].\n", gid, MyRank);
+        PyErr_Format(PyExc_ValueError, "Cannot find grid with GID [ %ld ] on MPI rank [%d].\n", gid, MyRank);
         return NULL;
     }
 

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -1,11 +1,25 @@
 #include "yt_combo.h"
 #include "string.h"
 
+//-------------------------------------------------------------------------------------------------------
+// Description :  List of libyt C extension python methods
+//
+// Note        :  1. List of python C extension methods functions.
+// 
+// Lists       :  libyt_method
+//-------------------------------------------------------------------------------------------------------
+static PyObject* libyt_method(PyObject *self, PyObject *args){
+  printf("Inside libyt_method!!!\n");
+  Py_INCREF(Py_None);
+  return Py_None; // return nothing in pthon function
+}
+
 
 // Define functions in module, list all libyt module methods here
 static PyMethodDef libyt_method_list[] =
 {
 // { "method_name", c_function_name, METH_VARARGS, "Description"},
+   {"method1", libyt_method, METH_VARARGS, "test method"},
    { NULL, NULL, 0, NULL } // sentinel
 };
 

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -5,21 +5,132 @@
 // Description :  List of libyt C extension python methods
 //
 // Note        :  1. List of python C extension methods functions.
+//                2. These function will be called in python, so the parameters indicate python 
+//                   input type.
 // 
-// Lists       :  libyt_method
+// Lists       :       Python Method         C Extension Function         
+//              .............................................................
+//                     derived_func          libyt_field_derived_func
 //-------------------------------------------------------------------------------------------------------
-static PyObject* libyt_method(PyObject *self, PyObject *args){
-  printf("Inside libyt_method!!!\n");
-  Py_INCREF(Py_None);
-  return Py_None; // return nothing in pthon function
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  libyt_field_derived_func
+// Description :  Use the derived_func defined inside yt_field struct to derived the field according to 
+//                this function.
+//
+// Note        :  1. Support only grid dimension = 3 for now.
+//                2. We assume that parallelism in yt will make each rank only has to deal with the local
+//                   grids. So we can always find one grid with id = gid inside grids_local.
+//                   (Maybe we can add feature get grids data from other rank in the future!)
+//                3. The returned numpy array data type is numpy.double.
+//                
+// Parameter   :  int : GID of the grid
+//                str : field name
+//
+// Return      :  numpy.ndarray
+//-------------------------------------------------------------------------------------------------------
+static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
+
+    // Parse the input arguments input by python.
+    // If not in the format libyt.derived_func( int , str ), raise an error
+    long  gid;
+    char *field_name;
+
+    if ( !PyArg_ParseTuple(args, "ls", &gid, &field_name) ){
+        PyErr_SetString(PyExc_ValueError, "Wrong input type, expect to be libyt.derived_func(int, str).");
+        return NULL;
+    }
+
+    // Get the derived_func define in field_list according to field_name.
+    // If cannot find field_name inside field_list, raise an error.
+    // If we successfully find the field_name, but the derived_func is not assigned (is NULL), raise an error.
+    void (*derived_func) (long, double*);
+    bool have_FieldName = false;
+
+    for (int v = 0; v < g_param_yt.num_fields; v++){
+        if ( strcmp(g_param_yt.field_list[v].field_name, field_name) == 0 ){
+            have_FieldName = true;
+            if ( g_param_yt.field_list[v].derived_func != NULL ){
+                derived_func = g_param_yt.field_list[v].derived_func;
+            }
+            else {
+                PyErr_Format(PyExc_AttributeError, "In field_list, field_name [ %s ], derived_func does not set properly.\n", 
+                             g_param_yt.field_list[v].field_name);
+                return NULL;
+            }
+            break;
+        }
+    }
+
+    if ( !have_FieldName ) {
+        PyErr_Format(PyExc_AttributeError, "Cannot find field_name [ %s ] in field_list.\n", field_name);
+        return NULL;
+    }
+
+    // Get the grid's dimension[3] according to the gid.
+    // We assume that parallelism in yt will make each rank only has to deal with the local grids.
+    // We can always find grid with id = gid inside grids_local.
+    int  grid_dimensions[3];
+    bool have_Grid = false;
+
+    for (int lid = 0; lid < g_param_yt.num_grids_local; lid++){
+        if ( g_param_yt.grids_local[lid].id == gid ){
+            have_Grid = true;
+            grid_dimensions[0] = g_param_yt.grids_local[lid].dimensions[0];
+            grid_dimensions[1] = g_param_yt.grids_local[lid].dimensions[1];
+            grid_dimensions[2] = g_param_yt.grids_local[lid].dimensions[2];
+            break;
+        }
+    }
+
+    if ( !have_Grid ){
+        int MyRank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+        PyErr_Format(PyExc_AttributeError, "Cannot find grid with GID [ %ld ] on MPI rank [%d].\n", gid, MyRank);
+        return NULL;
+    }
+
+    // Allocate 1D array with size of grid dimension, initialized with 0.
+    // derived_func will make changes to this array.
+    // This array will be wrapped by Numpy API and will be return. 
+    // The called object will then OWN this numpy array, so that we don't have to free it.
+    long gridTotalSize = grid_dimensions[0] * grid_dimensions[1] * grid_dimensions[2];
+    double *output = (double *) malloc( gridTotalSize * sizeof(double) );
+    for (long i = 0; i < gridTotalSize; i++) {
+        output[i] = (double) 0;
+    }
+
+    // Call the derived_func, result will be made inside output 1D array.
+    (*derived_func) (gid, output);
+
+    // Wrapping the C allocated 1D array into 3D numpy array.
+    int      nd = 3;
+    npy_intp dims[3] = {grid_dimensions[0], grid_dimensions[1], grid_dimensions[2]};
+    int      typenum = NPY_DOUBLE;
+    PyObject *derived_NpArray = PyArray_SimpleNewFromData(nd, dims, typenum, output);
+    PyArray_ENABLEFLAGS( (PyArrayObject*) derived_NpArray, NPY_ARRAY_OWNDATA);
+
+    return derived_NpArray;
 }
 
+//-------------------------------------------------------------------------------------------------------
+// Description :  Preparation for creating libyt python module
+//
+// Note        :  1. Contains data blocks for creating libyt python module.
+//                2. Only initialize libyt python module, not import to system yet.
+// 
+// Lists:      :  libyt_method_list       : Declare libyt C extension python methods.
+//                libyt_module_definition : Definition to libyt python module.
+//                PyInit_libyt            : Create libyt python module, and append python objects, 
+//                                          ex: dictionary.
+//-------------------------------------------------------------------------------------------------------
 
 // Define functions in module, list all libyt module methods here
 static PyMethodDef libyt_method_list[] =
 {
 // { "method_name", c_function_name, METH_VARARGS, "Description"},
-   {"method1", libyt_method, METH_VARARGS, "test method"},
+   {"derived_func", libyt_field_derived_func, METH_VARARGS, 
+    "Input GID and field name, and get the field data derived by derived_func."},
    { NULL, NULL, 0, NULL } // sentinel
 };
 
@@ -116,32 +227,3 @@ int init_libyt_module()
    return YT_SUCCESS;
 
 } // FUNCTION : init_libyt_module
-
-
-
-/*
-//-------------------------------------------------------------------------------------------------------
-// Function    :  Template
-// Description :  ???
-//
-// Note        :  1.
-//
-// Parameter   :  None
-//
-// Return      :  ?
-//-------------------------------------------------------------------------------------------------------
-static PyObject * c_function_name( PyObject *self, PyObject *args )
-{
-
-    const char *command;
-    int sts;
-
-    if ( !PyArg_ParseTuple( args, "s", &command ) )   return NULL;
-    sts = system( command );
-    return Py_BuildValue( "i", sts );
-
-} // METHOD : ?
-*/
-
-
-

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -23,6 +23,7 @@
 //                   grids. So we can always find one grid with id = gid inside grids_local.
 //                   (Maybe we can add feature get grids data from other rank in the future!)
 //                3. The returned numpy array data type is numpy.double.
+//                4. grid_dimensions[3] is in [x][y][z] coordinate.
 //                
 // Parameter   :  int : GID of the grid
 //                str : field name
@@ -76,9 +77,9 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
     for (int lid = 0; lid < g_param_yt.num_grids_local; lid++){
         if ( g_param_yt.grids_local[lid].id == gid ){
             have_Grid = true;
-            grid_dimensions[0] = g_param_yt.grids_local[lid].dimensions[0];
-            grid_dimensions[1] = g_param_yt.grids_local[lid].dimensions[1];
-            grid_dimensions[2] = g_param_yt.grids_local[lid].dimensions[2];
+            grid_dimensions[0] = g_param_yt.grids_local[lid].grid_dimensions[0];
+            grid_dimensions[1] = g_param_yt.grids_local[lid].grid_dimensions[1];
+            grid_dimensions[2] = g_param_yt.grids_local[lid].grid_dimensions[2];
             break;
         }
     }

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -1,7 +1,6 @@
 #include "yt_combo.h"
 #include "string.h"
 
-// TODO: This filename is a little bit misleading...
 
 // Define functions in module, list all libyt module methods here
 static PyMethodDef libyt_method_list[] =

--- a/src/init_python.cpp
+++ b/src/init_python.cpp
@@ -22,7 +22,6 @@ static int import_numpy();
 int init_python( int argc, char *argv[] )
 {
 
-// TODO: Where do we need this?
 // initialize Python interpreter
    Py_SetProgramName( Py_DecodeLocale("yt_inline", NULL) );
 
@@ -35,6 +34,7 @@ int init_python( int argc, char *argv[] )
       YT_ABORT(  "Initializing Python interpreter ... failed!\n" ); }
 
 // TODO: What are argc, argv use for?
+//       Probably can encode some settings, that must do before initialize Python.
 //       Length is hardcoded, each argv string size cannot longer than 1000.
 // set sys.argv
    wchar_t **wchar_t_argv = (wchar_t **) malloc(argc * sizeof(wchar_t *));

--- a/src/make_softlink.sh
+++ b/src/make_softlink.sh
@@ -1,3 +1,3 @@
-# If Makefile didn't generate soname and linker name, run this file.
+# If you delete libyt soname and linker name, run this file.
 ln -s libyt.so.1.0.0 libyt.so.1
 ln -s libyt.so.1     libyt.so

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -217,7 +217,7 @@ int yt_commit_grids()
    delete [] offsets;
 
    // Above all works like charm
-   g_param_libyt.add_grids = true;
+   g_param_libyt.commit_grids = true;
 
    return YT_SUCCESS;
 

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -4,14 +4,16 @@
 
 //-------------------------------------------------------------------------------------------------------
 // Function    :  yt_commit_grids
-// Description :  Add local grids to the libyt Python module
+// Description :  Add local grids and append field list info to the libyt Python module.
 //
 // Note        :  1. Store the input "grid" to libyt.hierarchy and libyt.grid_data to python
 //                2. Must call yt_set_parameter() in advance, which will  preallocate memory for NumPy arrays.
 //                3. Must call yt_get_fieldsPtr() in advance, so that g_param_yt knows the field_list array
 //                4. Must call yt_get_gridsPtr() in advance, so that g_param_yt knows the grids_local array
 //                   pointer.
-//                5. Pass the grids and hierarchy to YT in function append_grid()
+//                5. Append field list info to libyt python module.
+//                6. Pass the grids and hierarchy to YT in function append_grid().
+//                7. Check the local grids and field list.
 //
 // Parameter   :
 //
@@ -89,6 +91,26 @@ int yt_commit_grids()
       }
 
    }
+
+// check if each elements in yt_field field_list has correct value.
+   for ( int v = 0; v < g_param_yt.num_fields; v++ ){
+      yt_field field = g_param_yt.field_list[v];
+      if ( !(field.validate()) ){
+         YT_ABORT("Validating input field list element [%d] ... failed\n", v);
+      }
+   }
+
+// check if yt_field field_list has all the field_name unique
+   for ( int v1 = 0; v1 < g_param_yt.num_fields; v1++ ){
+      for ( int v2 = v1+1; v2 < g_param_yt.num_fields; v2++ ){
+         if ( strcmp(g_param_yt.field_list[v1].field_name, g_param_yt.field_list[v2].field_name) == 0 ){
+            YT_ABORT("field_name in field_list[%d] and field_list[%d] not unique!\n", v1, v2);
+         }
+      }
+   }
+
+// add field_list as dictionary
+   add_dict_field_list();
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Prepare to gather full hierarchy from different rank to root rank.

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -79,7 +79,7 @@ int yt_commit_grids()
       // data in each fields are not NULL
       for (int v = 0; v < g_param_yt.num_fields; v = v+1){
          if (grid.field_data[v] == NULL)
-            log_warning( "Grid [%ld], field_data [%s] is NULL, not set yet!", grid.id, g_param_yt.field_labels[v]);
+            log_warning( "Grid [%ld], field_data [%s] is NULL, not set yet!", grid.id, g_param_yt.field_list[v].field_name);
       }
 
    }

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -20,16 +20,21 @@ int yt_commit_grids()
 {
 
 // check if libyt has been initialized
-   if ( !g_param_libyt.libyt_initialized )
+   if ( !g_param_libyt.libyt_initialized ){
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // check if YT parameters have been set
-   if ( !g_param_libyt.param_yt_set )
+   if ( !g_param_libyt.param_yt_set ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
-   if ( !g_param_libyt.get_gridsPtr )
+   if ( !g_param_libyt.get_gridsPtr ){
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
+   log_info("Loading grids to yt ...\n");
 
 // check each grids individually
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1) {
@@ -218,6 +223,7 @@ int yt_commit_grids()
 
    // Above all works like charm
    g_param_libyt.commit_grids = true;
+   log_info("Loading grids to yt ... done.\n");
 
    return YT_SUCCESS;
 

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -145,7 +145,7 @@ int yt_commit_grids()
       for (int d = 0; d < 3; d = d+1) {
          hierarchy_local[i].left_edge[d]  = grid.left_edge[d];
          hierarchy_local[i].right_edge[d] = grid.right_edge[d];
-         hierarchy_local[i].dimensions[d] = grid.dimensions[d];
+         hierarchy_local[i].dimensions[d] = grid.grid_dimensions[d];
       }
 
       hierarchy_local[i].particle_count = grid.particle_count;
@@ -213,9 +213,9 @@ int yt_commit_grids()
 
       // Load from hierarchy_full
       for (int d = 0; d < 3; d = d+1) {
-         grid_combine.left_edge[d]  = hierarchy_full[i].left_edge[d];
-         grid_combine.right_edge[d] = hierarchy_full[i].right_edge[d];
-         grid_combine.dimensions[d] = hierarchy_full[i].dimensions[d];
+         grid_combine.left_edge[d]       = hierarchy_full[i].left_edge[d];
+         grid_combine.right_edge[d]      = hierarchy_full[i].right_edge[d];
+         grid_combine.grid_dimensions[d] = hierarchy_full[i].dimensions[d];
       }
       grid_combine.particle_count = hierarchy_full[i].particle_count;
       grid_combine.id             = hierarchy_full[i].id;

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -8,9 +8,10 @@
 //
 // Note        :  1. Store the input "grid" to libyt.hierarchy and libyt.grid_data to python
 //                2. Must call yt_set_parameter() in advance, which will  preallocate memory for NumPy arrays.
-//                3. Must call yt_get_gridsPtr() in advance, so that g_param_yt knows the grids_local array
+//                3. Must call yt_get_fieldsPtr() in advance, so that g_param_yt knows the field_list array
+//                4. Must call yt_get_gridsPtr() in advance, so that g_param_yt knows the grids_local array
 //                   pointer.
-//                4. Pass the grids and hierarchy to YT in function append_grid()
+//                5. Pass the grids and hierarchy to YT in function append_grid()
 //
 // Parameter   :
 //
@@ -27,6 +28,11 @@ int yt_commit_grids()
 // check if YT parameters have been set
    if ( !g_param_libyt.param_yt_set ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_get_fieldsPtr()
+   if ( !g_param_libyt.get_fieldsPtr ){
+      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
    }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -3,7 +3,7 @@
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  yt_add_grids
+// Function    :  yt_commit_grids
 // Description :  Add local grids to the libyt Python module
 //
 // Note        :  1. Store the input "grid" to libyt.hierarchy and libyt.grid_data to python
@@ -16,7 +16,7 @@
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
-int yt_add_grids()
+int yt_commit_grids()
 {
 
 // check if libyt has been initialized
@@ -221,4 +221,4 @@ int yt_add_grids()
 
    return YT_SUCCESS;
 
-} // FUNCTION : yt_add_grids
+} // FUNCTION : yt_commit_grids

--- a/src/yt_finalize.cpp
+++ b/src/yt_finalize.cpp
@@ -10,7 +10,7 @@
 //
 // Note        :  1. Do not reinitialize libyt (i.e., calling yt_init()) after calling this function
 //                   ==> Some extensions (e.g., NumPy) may not work properly
-//                2. Make sure that the user has follow the libyt workflow.
+//                2. Make sure that the user has follow the full libyt workflow.
 //
 // Parameter   :  None
 //

--- a/src/yt_finalize.cpp
+++ b/src/yt_finalize.cpp
@@ -10,6 +10,7 @@
 //
 // Note        :  1. Do not reinitialize libyt (i.e., calling yt_init()) after calling this function
 //                   ==> Some extensions (e.g., NumPy) may not work properly
+//                2. Make sure that the user has follow the libyt workflow.
 //
 // Parameter   :  None
 //
@@ -22,6 +23,9 @@ int yt_finalize()
 
 // check whether libyt has been initialized
    if ( !g_param_libyt.libyt_initialized )   YT_ABORT( "Calling yt_finalize() before yt_init()!\n" );
+
+// check if all the libyt allocated resource are freed
+   if ( !g_param_libyt.free_gridsPtr ) YT_ABORT("Please invoke yt_free_gridsPtr() before calling yt_finalize().\n");
 
 // free all libyt resources
    Py_Finalize();

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -38,6 +38,9 @@ int yt_free_gridsPtr()
       YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
    }
 
+   // Make sure every rank has reach to this point
+   MPI_Barrier( MPI_COMM_WORLD );
+
    // free resources to prepare for the next round
    g_param_libyt.param_yt_set = false;
    g_param_libyt.get_gridsPtr = false;

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -18,7 +18,27 @@
 //
 int yt_free_gridsPtr()
 {
-// free resources to prepare for the next round
+// check if libyt has been initialized
+   if ( !g_param_libyt.libyt_initialized ){
+      YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if YT parameters have been set
+   if ( !g_param_libyt.param_yt_set ){
+      YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
+   if ( !g_param_libyt.get_gridsPtr ){
+      YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_commit_grids(), so that grids are appended to YT.
+   if ( !g_param_libyt.commit_grids ){
+      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
+   }
+
+   // free resources to prepare for the next round
    g_param_libyt.param_yt_set = false;
    g_param_libyt.get_gridsPtr = false;
    g_param_libyt.commit_grids = false;
@@ -37,6 +57,8 @@ int yt_free_gridsPtr()
    PyDict_Clear( g_py_param_user );
 
    PyRun_SimpleString( "gc.collect()" );
+
+   g_param_libyt.free_gridsPtr = true;
 
    return YT_SUCCESS;
 } // FUNCTION: yt_free_gridsPtr()

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -1,0 +1,42 @@
+#include "yt_combo.h"
+#include "libyt.h"
+
+
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_free_gridsPtr()
+// Description :  Refresh the python yt state after finish inline-analysis
+//
+// Note        :  1. Call and use by user, after they are done with all the inline-analysis in this 
+//                   round.
+//
+// Parameter   :  None
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+//
+int yt_free_gridsPtr()
+{
+// free resources to prepare for the next round
+   g_param_libyt.param_yt_set = false;
+   g_param_libyt.get_gridsPtr = false;
+   g_param_libyt.commit_grids = false;
+   g_param_libyt.counter ++;
+
+   for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
+      delete [] g_param_yt.grids_local[i].field_data;
+   }
+   delete [] g_param_yt.grids_local;
+   delete [] g_param_yt.num_grids_local_MPI;
+   g_param_yt.init();
+   
+   PyDict_Clear( g_py_grid_data  );
+   PyDict_Clear( g_py_hierarchy  );
+   PyDict_Clear( g_py_param_yt   );
+   PyDict_Clear( g_py_param_user );
+
+   PyRun_SimpleString( "gc.collect()" );
+
+   return YT_SUCCESS;
+} // FUNCTION: yt_free_gridsPtr()

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -47,6 +47,8 @@ int yt_free_gridsPtr()
    g_param_libyt.commit_grids = false;
    g_param_libyt.counter ++;
 
+   // TODO: Should we free yt_field array g_param_yt.field_list here?
+   //       For now, user declare and input yt_field array's pointer to libyt.
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
       delete [] g_param_yt.grids_local[i].field_data;
    }

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -28,6 +28,11 @@ int yt_free_gridsPtr()
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
    }
 
+// check if user has call yt_get_fieldsPtr()
+   if ( !g_param_libyt.get_fieldsPtr ){
+      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
    if ( !g_param_libyt.get_gridsPtr ){
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
@@ -42,18 +47,21 @@ int yt_free_gridsPtr()
    MPI_Barrier( MPI_COMM_WORLD );
 
    // free resources to prepare for the next round
-   g_param_libyt.param_yt_set = false;
-   g_param_libyt.get_gridsPtr = false;
-   g_param_libyt.commit_grids = false;
+   g_param_libyt.param_yt_set  = false;
+   g_param_libyt.get_fieldsPtr = false;
+   g_param_libyt.get_gridsPtr  = false;
+   g_param_libyt.commit_grids  = false;
    g_param_libyt.counter ++;
 
-   // TODO: Should we free yt_field array g_param_yt.field_list here?
-   //       For now, user declare and input yt_field array's pointer to libyt.
+   // Free grids_local, num_grids_local_MPI, field_list
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
       delete [] g_param_yt.grids_local[i].field_data;
    }
    delete [] g_param_yt.grids_local;
    delete [] g_param_yt.num_grids_local_MPI;
+   delete [] g_param_yt.field_list;
+
+   // Reset g_param_yt
    g_param_yt.init();
    
    PyDict_Clear( g_py_grid_data  );

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -59,8 +59,7 @@ int check_procedure( const char *callFunc ){
 int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
 
 	if ( check_procedure( __FUNCTION__ ) != YT_SUCCESS ){
-		log_error( "Please follow the libyt procedure, terminating the process.\n" );
-		abort();
+		YT_ABORT( "Please follow the libyt procedure.\n" );
 	}
 
 	bool have_Grid = false;
@@ -108,8 +107,7 @@ int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
 int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data){
 
 	if ( check_procedure( __FUNCTION__ ) != YT_SUCCESS ){
-		log_error( "Please follow the libyt procedure, terminating the process.\n" );
-		abort();
+		YT_ABORT( "Please follow the libyt procedure.\n" );
 	}
 
 	bool have_Grid  = false;

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -96,15 +96,15 @@ int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
 //
 // Parameter   :  const long   gid              : Target grid id.
 //                const char  *field_name       : Target field name.
-//                void       **field_data       : Store the field_data pointer to here.
+//                yt_data     *field_data       : Store the yt_data struct pointer that points to data here.
 //                
-// Example     :  void *Data;
+// Example     :  yt_data Data;
 //                yt_getGridInfo_FieldData( gid, "field_name", &Data );
-//                double *FieldData = (double *) Data;
+//                double *FieldData = (double *) Data.data_ptr;
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
-int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data){
+int yt_getGridInfo_FieldData( const long gid, const char *field_name, yt_data *field_data){
 
 	if ( check_procedure( __FUNCTION__ ) != YT_SUCCESS ){
 		YT_ABORT( "Please follow the libyt procedure.\n" );
@@ -119,7 +119,12 @@ int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **fie
 			for ( int v = 0; v < g_param_yt.num_fields; v++ ){
 				if ( strcmp(g_param_yt.field_list[v].field_name, field_name) == 0 ){
 					have_Field = true;
-					*field_data = g_param_yt.grids_local[lid].field_data[v];
+
+					(*field_data).data_ptr = g_param_yt.grids_local[lid].field_data[v].data_ptr;
+					for ( int d = 0; d < 3; d++ ){
+						(*field_data).data_dim[d] = g_param_yt.grids_local[lid].field_data[v].data_dim[d];
+					}
+					
 					break;
 				}
 			}

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -1,0 +1,96 @@
+#include "yt_combo.h"
+#include "libyt.h"
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_getGridInfo_Dimensions
+// Description :  Get dimension of the grid with grid id = gid.
+//
+// Note        :  1. This function will be called inside user's field derived_func.
+//                2. Return YT_FAIL if cannot find grid id = gid.
+//
+// Parameter   :  const long  gid               : Target grid id
+//                int         (*dimensions)[3]  : Write result to this pointer.
+//                
+// Example     :  int dim[3];
+//                yt_getGridInfo_Dimensions( gid, &dim );
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
+
+	bool have_Grid = false;
+
+	for ( int lid = 0; lid < g_param_yt.num_grids_local; lid++ ){
+		if ( g_param_yt.grids_local[lid].id == gid ){
+			have_Grid = true;
+			for ( int d = 0; d < 3; d++ ){
+				(*dimensions)[d] = g_param_yt.grids_local[lid].dimensions[d];
+			}
+			break;
+		}
+	}
+
+	if ( !have_Grid ){
+		int MyRank;
+		MPI_Comm_rank( MPI_COMM_WORLD, &MyRank );
+		log_warning("In %s, cannot find grid with GID [ %ld ] on MPI rank [%d].\n", 
+			         __FUNCTION__, gid, MyRank);
+		return YT_FAIL;
+	}
+
+	return YT_SUCCESS;
+}
+
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_getGridInfo_FieldData
+// Description :  Get field_data of field_name in the grid with grid id = gid .
+//
+// Note        :  1. This function will be called inside user's field derived_func.
+//                2. Return YT_FAIL if cannot find grid id = gid or if field_name is not in field_list.
+//                3. User should cast to their own datatype after receiving the pointer.
+//
+// Parameter   :  const long   gid              : Target grid id.
+//                const char  *field_name       : Target field name.
+//                void       **field_data       : Store the field_data pointer to here.
+//                
+// Example     :  void *Data;
+//                yt_getGridInfo_FieldData( gid, "field_name", &Data );
+//                double *FieldData = (double *) Data;
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data){
+
+	bool have_Grid  = false;
+	bool have_Field = false;
+
+	for ( int lid = 0; lid < g_param_yt.num_grids_local; lid++ ){
+		if ( g_param_yt.grids_local[lid].id == gid ){
+			have_Grid = true;
+			for ( int v = 0; v < g_param_yt.num_fields; v++ ){
+				if ( strcmp(g_param_yt.field_list[v].field_name, field_name) == 0 ){
+					have_Field = true;
+					*field_data = g_param_yt.grids_local[lid].field_data[v];
+					break;
+				}
+			}
+			break;
+		}
+	}
+
+	if ( !have_Field ){
+		log_warning("In %s, cannot find field_name [ %s ] in field_list.\n", __FUNCTION__, field_name);
+		return YT_FAIL;
+	}
+
+	if ( !have_Grid ){
+		int MyRank;
+		MPI_Comm_rank( MPI_COMM_WORLD, &MyRank );
+		log_warning("In %s, cannot find grid with GID [ %ld ] on MPI rank [%d].\n", 
+			         __FUNCTION__, gid, MyRank);
+		return YT_FAIL;
+	}
+
+	return YT_SUCCESS;
+}

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -68,7 +68,7 @@ int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
 		if ( g_param_yt.grids_local[lid].id == gid ){
 			have_Grid = true;
 			for ( int d = 0; d < 3; d++ ){
-				(*dimensions)[d] = g_param_yt.grids_local[lid].dimensions[d];
+				(*dimensions)[d] = g_param_yt.grids_local[lid].grid_dimensions[d];
 			}
 			break;
 		}

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -2,11 +2,51 @@
 #include "libyt.h"
 
 //-------------------------------------------------------------------------------------------------------
+// Function    :  check_procedure
+// Description :  Check if libyt is properly set.
+//
+// Note        :  1. This function will only be use in yt_getGridInfo_*().
+//
+// Parameter   :  const char *callFunc : function that calls check_procedure.
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int check_procedure( const char *callFunc ){
+
+	// check if libyt has been initialized
+   	if ( !g_param_libyt.libyt_initialized ){
+    	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_init() before calling %s()!\n", callFunc );
+   	}
+
+	// check if YT parameters have been set
+   	if ( !g_param_libyt.param_yt_set ){
+    	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_set_parameter() before calling %s()!\n", callFunc );
+   	}
+
+	// check if user has call yt_get_fieldsPtr()
+   	if ( !g_param_libyt.get_fieldsPtr ){
+    	YT_ABORT( "Please follow the libyt procedure, forgot to invode yt_get_fieldsPtr() before calling %s()!\n", callFunc );
+   	}
+
+	// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
+   	if ( !g_param_libyt.get_gridsPtr ){
+      	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_get_gridsPtr() before calling %s()!\n", callFunc );
+   	}
+
+	// check if user has call yt_commit_grids(), so that grids are appended to YT.
+   	if ( !g_param_libyt.commit_grids ){
+      	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_commit_grids() before calling %s()!\n", callFunc );
+   	}
+
+	return YT_SUCCESS;
+}
+//-------------------------------------------------------------------------------------------------------
 // Function    :  yt_getGridInfo_Dimensions
 // Description :  Get dimension of the grid with grid id = gid.
 //
 // Note        :  1. This function will be called inside user's field derived_func.
 //                2. Return YT_FAIL if cannot find grid id = gid.
+//                3. grid_dimensions is defined in [x][y][z] <-> [0][1][2] coordinate.
 //
 // Parameter   :  const long  gid               : Target grid id
 //                int         (*dimensions)[3]  : Write result to this pointer.
@@ -17,6 +57,11 @@
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
 int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
+
+	if ( check_procedure( __FUNCTION__ ) != YT_SUCCESS ){
+		log_error( "Please follow the libyt procedure, terminating the process.\n" );
+		abort();
+	}
 
 	bool have_Grid = false;
 
@@ -61,6 +106,11 @@ int yt_getGridInfo_Dimensions( const long gid, int (*dimensions)[3] ){
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
 int yt_getGridInfo_FieldData( const long gid, const char *field_name, void **field_data){
+
+	if ( check_procedure( __FUNCTION__ ) != YT_SUCCESS ){
+		log_error( "Please follow the libyt procedure, terminating the process.\n" );
+		abort();
+	}
 
 	bool have_Grid  = false;
 	bool have_Field = false;

--- a/src/yt_get_fieldsPtr.cpp
+++ b/src/yt_get_fieldsPtr.cpp
@@ -1,0 +1,41 @@
+#include "yt_combo.h"
+#include "libyt.h"
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_get_fieldsPtr
+// Description :  Get pointer of the array of struct yt_field with length num_fields.
+//
+// Note        :  1. User should call this function after yt_set_parameter(), since we need num_fields.
+//
+// Parameter   :  yt_field **field_list  : Initialize and store the field list array under this pointer 
+//                                         points to.
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+//
+int yt_get_gridsPtr( yt_field **field_list )
+{
+	// check if libyt has been initialized
+   	if ( !g_param_libyt.libyt_initialized ){
+    	YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );     	
+   	}
+
+	// check if yt_set_parameter() have been called
+   	if ( !g_param_libyt.param_yt_set ) {
+    	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+    }
+
+   	log_info( "Getting pointer to field list information ...\n" );
+
+	// Initialize the field_list array.
+	*field_list = new yt_field [g_param_yt.num_fields];
+
+	// Store the field_list to g_param_yt
+	g_param_yt.field_list = *field_list;
+
+	// Above all works like charm
+	g_param_libyt.get_fieldsPtr = true;
+	log_info( "Getting pointer to field list information  ... done.\n" );
+	
+	return YT_SUCCESS;
+}

--- a/src/yt_get_fieldsPtr.cpp
+++ b/src/yt_get_fieldsPtr.cpp
@@ -13,7 +13,7 @@
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
 //
-int yt_get_gridsPtr( yt_field **field_list )
+int yt_get_fieldsPtr( yt_field **field_list )
 {
 	// check if libyt has been initialized
    	if ( !g_param_libyt.libyt_initialized ){

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -18,13 +18,17 @@
 //
 int yt_get_gridsPtr( yt_grid **grids_local )
 {
+	// check if libyt has been initialized
+   	if ( !g_param_libyt.libyt_initialized ){
+    	YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );     	
+   	}
+
 	// check if yt_set_parameter() have been called
-   	if ( g_param_libyt.param_yt_set ) {
-    	log_info( "Getting pointer to local grids array  ...\n" );
-   	}
-   	else {
-   		YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
-   	}
+   	if ( !g_param_libyt.param_yt_set ) {
+    	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+    }
+
+   	log_info( "Getting pointer to local grids information ...\n" );
 
    	// Get the MPI rank
    	int MyRank;
@@ -47,7 +51,7 @@ int yt_get_gridsPtr( yt_grid **grids_local )
 
 	// Above all works like charm
 	g_param_libyt.get_gridsPtr = true;
-	log_info( "Getting pointer to local grids array  ... done.\n" );
+	log_info( "Getting pointer to local grids information  ... done.\n" );
 	
 	return YT_SUCCESS;
 }

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -5,7 +5,11 @@
 // Function    :  yt_get_gridsPtr
 // Description :  Get pointer of the array of struct yt_grid with length num_grids_local.
 //
-// Note        :  1. User should call this function after yt_set_parameter(), since we need num_grids_local.
+// Note        :  1. User should call this function after yt_set_parameter() and yt_get_fieldsPtr, 
+//                   since we need num_grids_local, and field info.
+//                2. Initialize field_data in one grid with
+//                   (1) data_dim[3] = {0, 0, 0}
+//                   (2) data_ptr    = NULL
 //
 // Parameter   :  yt_grid **grids_local : Initialize and store the grid structure array under this 
 //                                        pointer points to.
@@ -41,10 +45,16 @@ int yt_get_gridsPtr( yt_grid **grids_local )
 	// and each fields data are set to NULL, so that we can check if user input the data
 	*grids_local = new yt_grid [g_param_yt.num_grids_local];
 	for ( int id = 0; id < g_param_yt.num_grids_local; id = id+1 ){
+		
 		(*grids_local)[id].proc_num     = MyRank;
-		(*grids_local)[id].field_data   = new void* [g_param_yt.num_fields];
-		for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1){
-			(*grids_local)[id].field_data[fid] = NULL;
+		(*grids_local)[id].field_data   = new yt_data [g_param_yt.num_fields];
+		
+		// Dealing with individual field in one grid
+		for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1 ){
+			for ( int d = 0; d < 3; d++ ){
+				(*grids_local)[id].field_data[fid].data_dim[d] = 0;
+			}
+			(*grids_local)[id].field_data[fid].data_ptr = NULL;
 		}
 	}
 

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -47,6 +47,7 @@ int yt_get_gridsPtr( yt_grid **grids_local )
 
 	// Above all works like charm
 	g_param_libyt.get_gridsPtr = true;
+	log_info( "Getting pointer to local grids array  ... done.\n" );
 	
 	return YT_SUCCESS;
 }

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -25,6 +25,11 @@ int yt_get_gridsPtr( yt_grid **grids_local )
     	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
     }
 
+    // check if yt_get_fieldsPtr() have been called
+    if ( !g_param_libyt.get_fieldsPtr ) {
+    	YT_ABORT( "Please invoke yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
+    }
+
    	log_info( "Getting pointer to local grids information ...\n" );
 
    	// Get the MPI rank

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -1,9 +1,6 @@
 #include "yt_combo.h"
 #include "libyt.h"
 
-// TODO: Function name a little bit misleading..., name a new one later.
-
-
 //-------------------------------------------------------------------------------------------------------
 // Function    :  yt_get_gridsPtr
 // Description :  Get pointer of the array of struct yt_grid with length num_grids_local.

--- a/src/yt_init.cpp
+++ b/src/yt_init.cpp
@@ -44,7 +44,7 @@ int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt )
    log_debug( "   script  = %s\n", g_param_libyt.script );
 
 // create libyt module, should be before init_python
-   if (create_libyt_module() == YT_FAIL) {
+   if ( create_libyt_module() == YT_FAIL ) {
       return YT_FAIL;
    }
 

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -41,7 +41,7 @@ int yt_inline( char *function_name )
 // Not sure if we need this MPI_Barrier
    MPI_Barrier(MPI_COMM_WORLD);
 
-   log_info( "Performing YT inline analysis ...\n" );
+   log_info( "Performing YT inline analysis %s.%s() ...\n", g_param_libyt.script, function_name );
 
 // execute function in python script
    int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
@@ -56,7 +56,7 @@ int yt_inline( char *function_name )
 
    free( CallYT );
 
-   log_info( "Performing YT inline analysis ... done.\n" );
+   log_info( "Performing YT inline analysis %s.%s() ... done.\n", g_param_libyt.script, function_name );
 
    return YT_SUCCESS;
 

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -4,11 +4,12 @@
 
 
 //-------------------------------------------------------------------------------------------------------
-// Function    :  yt_inline
+// Function    :  yt_inline_argument
 // Description :  Execute the YT inline analysis script
 //
 // Note        :  1. Python script name is stored in "g_param_libyt.script"
 //                2. This python script must contain function of <function_name> you called.
+//                3. Must give argc (argument count), even if there are no arguments.
 //
 // Parameter   :  char *function_name : function name in python script 
 //                int  argc           : input arguments count
@@ -16,7 +17,7 @@
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
-int yt_inline( char *function_name, int argc, ... ){
+int yt_inline_argument( char *function_name, int argc, ... ){
 // check if libyt has been initialized
    if ( !g_param_libyt.libyt_initialized ){
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
@@ -42,64 +43,102 @@ int yt_inline( char *function_name, int argc, ... ){
 
    log_info( "Performing YT inline analysis ...\n");
 
-   if( argc == 0 ){
-      int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
-      const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
-      char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
-      sprintf( CallYT, "%s.%s()", g_param_libyt.script, function_name );
+   va_list Args, Args_len;
+   va_start(Args, argc);
+   va_copy(Args_len, Args);
 
-      if ( PyRun_SimpleString( CallYT ) == 0 ){
-         log_debug( "Invoking \"%s\" ... done\n", CallYT );
-      }
-      else{
-         YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
-      }
+   // Count inline function width = .<function_name>() + '\0'
+   int InlineFunctionWidth = strlen(function_name) + 4; 
+   for(int i = 0; i < argc; i++){
 
-      log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
-      free( CallYT );
+      if ( i != 0 ) InlineFunctionWidth++; // comma "," in called function
+      
+      InlineFunctionWidth = InlineFunctionWidth + strlen(va_arg(Args_len, char*));
+   }
+
+   // Allocate command, and connect input arguments 
+   const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
+   char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
+   strcpy( CallYT, g_param_libyt.script );
+   strcat( CallYT, ".");
+   strcat( CallYT, function_name);
+   strcat( CallYT, "(");
+   for(int i = 0; i < argc; i++){
+
+      if ( i != 0 ) strcat( CallYT, ",");
+
+      strcat( CallYT, va_arg(Args, char*));
+   }
+   strcat( CallYT, ")");
+
+   va_end(Args_len);
+   va_end(Args);
+
+   if ( PyRun_SimpleString( CallYT ) == 0 ){
+      log_debug( "Invoking \"%s\" ... done\n", CallYT );
    }
    else{
-      va_list Args, Args_len;
-      va_start(Args, argc);
-      va_copy(Args_len, Args);
-
-      // Count inline function width = .<function_name>() + '\0'
-      int InlineFunctionWidth = strlen(function_name) + 4; 
-      for(int i = 0; i < argc; i++){
-
-         if ( i != 0 ) InlineFunctionWidth++; // comma "," in called function
-         
-         InlineFunctionWidth = InlineFunctionWidth + strlen(va_arg(Args_len, char*));
-      }
-
-      // Allocate command, and connect input arguments 
-      const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
-      char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
-      strcpy( CallYT, g_param_libyt.script );
-      strcat( CallYT, ".");
-      strcat( CallYT, function_name);
-      strcat( CallYT, "(");
-      for(int i = 0; i < argc; i++){
-
-         if ( i != 0 ) strcat( CallYT, ",");
-
-         strcat( CallYT, va_arg(Args, char*));
-      }
-      strcat( CallYT, ")");
-
-      va_end(Args_len);
-      va_end(Args);
-
-      if ( PyRun_SimpleString( CallYT ) == 0 ){
-         log_debug( "Invoking \"%s\" ... done\n", CallYT );
-      }
-      else{
-         YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
-      }
-      
-      log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
-      free( CallYT );
+      YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
    }
+   
+   log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
+   free( CallYT );
+
+   return YT_SUCCESS;
+}
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_inline
+// Description :  Execute the YT inline analysis script
+//
+// Note        :  1. Python script name is stored in "g_param_libyt.script"
+//                2. This python script must contain function of <function_name> you called.
+//                3. This python function must not contain input arguments.
+//
+// Parameter   :  char *function_name : function name in python script
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int yt_inline( char *function_name ){
+// check if libyt has been initialized
+   if ( !g_param_libyt.libyt_initialized ){
+      YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if YT parameters have been set
+   if ( !g_param_libyt.param_yt_set ){
+      YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
+   if ( !g_param_libyt.get_gridsPtr ){
+      YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_commit_grids(), so that grids are appended to YT.
+   if ( !g_param_libyt.commit_grids ){
+      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// Not sure if we need this MPI_Barrier
+   MPI_Barrier(MPI_COMM_WORLD);
+
+   log_info( "Performing YT inline analysis ...\n");
+
+   int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
+   const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
+   char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
+   sprintf( CallYT, "%s.%s()", g_param_libyt.script, function_name );
+
+   if ( PyRun_SimpleString( CallYT ) == 0 ){
+      log_debug( "Invoking \"%s\" ... done\n", CallYT );
+   }
+   else{
+      YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
+   }
+
+   log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
+   free( CallYT );
 
    return YT_SUCCESS;
 }

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -11,7 +11,8 @@
 // Note        :  1. Python script name is stored in "g_param_libyt.script"
 //                2. This python script must contain function of <function_name> you called.
 //
-// Parameter   :  char *function_name : the function inside python script that you want to execute.
+// Parameter   :  char *function_name : the function inside python script that you want to execute, 
+//                                      ex: def function_name():
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
@@ -49,10 +50,12 @@ int yt_inline( char *function_name )
    char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
    sprintf( CallYT, "%s.%s()", g_param_libyt.script, function_name );
 
-   if ( PyRun_SimpleString( CallYT ) == 0 )
+   if ( PyRun_SimpleString( CallYT ) == 0 ){
       log_debug( "Invoking \"%s\" ... done\n", CallYT );
-   else
+   }
+   else{
       YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
+   }
 
    free( CallYT );
 
@@ -61,3 +64,45 @@ int yt_inline( char *function_name )
    return YT_SUCCESS;
 
 } // FUNCTION : yt_inline
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_inline
+// Description :  Execute the YT inline analysis script
+//
+// Note        :  1. Python script name is stored in "g_param_libyt.script"
+//                2. This python script must contain function of <function_name> you called.
+//
+// Parameter   :  char *function_name  : the function inside python script that you want to execute, 
+//                                       ex: def function_name():
+//                int     argc         : input arguments length
+//                char  **argv         : input parameter
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int yt_inline(char *function_name, int argc, char **argv){
+// check if libyt has been initialized
+   if ( !g_param_libyt.libyt_initialized ){
+      YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if YT parameters have been set
+   if ( !g_param_libyt.param_yt_set ){
+      YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
+   if ( !g_param_libyt.get_gridsPtr ){
+      YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_commit_grids(), so that grids are appended to YT.
+   if ( !g_param_libyt.commit_grids ){
+      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// Not sure if we need this MPI_Barrier
+   MPI_Barrier(MPI_COMM_WORLD);
+
+
+   return YT_SUCCESS;
+}

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -66,6 +66,7 @@ int yt_inline()
    g_param_libyt.add_grids    = false;
    g_param_libyt.counter ++;
 
+// TODO: Reconsider who should free this pointer
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
       delete [] g_param_yt.grids_local[i].field_data;
    }

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -28,6 +28,11 @@ int yt_inline_argument( char *function_name, int argc, ... ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
    }
 
+// check if user has call yt_get_fieldsPtr()
+   if ( !g_param_libyt.get_fieldsPtr ){
+      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
+
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
    if ( !g_param_libyt.get_gridsPtr ){
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
@@ -108,6 +113,11 @@ int yt_inline( char *function_name ){
 // check if YT parameters have been set
    if ( !g_param_libyt.param_yt_set ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
+
+// check if user has call yt_get_fieldsPtr()
+   if ( !g_param_libyt.get_fieldsPtr ){
+      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
    }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -1,9 +1,8 @@
 #include "yt_combo.h"
+#include <stdarg.h>
 #include "libyt.h"
 
 
-
-
 //-------------------------------------------------------------------------------------------------------
 // Function    :  yt_inline
 // Description :  Execute the YT inline analysis script
@@ -11,14 +10,13 @@
 // Note        :  1. Python script name is stored in "g_param_libyt.script"
 //                2. This python script must contain function of <function_name> you called.
 //
-// Parameter   :  char *function_name : the function inside python script that you want to execute, 
-//                                      ex: def function_name():
+// Parameter   :  char *function_name : function name in python script 
+//                int  argc           : input arguments count
+//                ...                 : list of arguments, should be input as (char*)
 //
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
-int yt_inline( char *function_name )
-{
-
+int yt_inline( char *function_name, int argc, ... ){
 // check if libyt has been initialized
    if ( !g_param_libyt.libyt_initialized ){
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
@@ -42,67 +40,66 @@ int yt_inline( char *function_name )
 // Not sure if we need this MPI_Barrier
    MPI_Barrier(MPI_COMM_WORLD);
 
-   log_info( "Performing YT inline analysis %s.%s() ...\n", g_param_libyt.script, function_name );
+   log_info( "Performing YT inline analysis ...\n");
 
-// execute function in python script
-   int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
-   const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
-   char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
-   sprintf( CallYT, "%s.%s()", g_param_libyt.script, function_name );
+   if( argc == 0 ){
+      int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
+      const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
+      char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
+      sprintf( CallYT, "%s.%s()", g_param_libyt.script, function_name );
 
-   if ( PyRun_SimpleString( CallYT ) == 0 ){
-      log_debug( "Invoking \"%s\" ... done\n", CallYT );
+      if ( PyRun_SimpleString( CallYT ) == 0 ){
+         log_debug( "Invoking \"%s\" ... done\n", CallYT );
+      }
+      else{
+         YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
+      }
+
+      log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
+      free( CallYT );
    }
    else{
-      YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
+      va_list Args, Args_len;
+      va_start(Args, argc);
+      va_copy(Args_len, Args);
+
+      // Count inline function width = .<function_name>() + '\0'
+      int InlineFunctionWidth = strlen(function_name) + 4; 
+      for(int i = 0; i < argc; i++){
+
+         if ( i != 0 ) InlineFunctionWidth++; // comma "," in called function
+         
+         InlineFunctionWidth = InlineFunctionWidth + strlen(va_arg(Args_len, char*));
+      }
+
+      // Allocate command, and connect input arguments 
+      const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
+      char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
+      strcpy( CallYT, g_param_libyt.script );
+      strcat( CallYT, ".");
+      strcat( CallYT, function_name);
+      strcat( CallYT, "(");
+      for(int i = 0; i < argc; i++){
+
+         if ( i != 0 ) strcat( CallYT, ",");
+
+         strcat( CallYT, va_arg(Args, char*));
+      }
+      strcat( CallYT, ")");
+
+      // DEBUG:
+      printf("#FLAG, %s\n", CallYT);
+
+      if ( PyRun_SimpleString( CallYT ) == 0 ){
+         log_debug( "Invoking \"%s\" ... done\n", CallYT );
+      }
+      else{
+         YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
+      }
+      
+      log_info( "Performing YT inline analysis <%s> ... done.\n", CallYT);
+      free( CallYT );
    }
-
-   free( CallYT );
-
-   log_info( "Performing YT inline analysis %s.%s() ... done.\n", g_param_libyt.script, function_name );
-
-   return YT_SUCCESS;
-
-} // FUNCTION : yt_inline
-
-//-------------------------------------------------------------------------------------------------------
-// Function    :  yt_inline
-// Description :  Execute the YT inline analysis script
-//
-// Note        :  1. Python script name is stored in "g_param_libyt.script"
-//                2. This python script must contain function of <function_name> you called.
-//
-// Parameter   :  char *function_name  : the function inside python script that you want to execute, 
-//                                       ex: def function_name():
-//                int     argc         : input arguments length
-//                char  **argv         : input parameter
-//
-// Return      :  YT_SUCCESS or YT_FAIL
-//-------------------------------------------------------------------------------------------------------
-int yt_inline(char *function_name, int argc, char **argv){
-// check if libyt has been initialized
-   if ( !g_param_libyt.libyt_initialized ){
-      YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// check if YT parameters have been set
-   if ( !g_param_libyt.param_yt_set ){
-      YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
-   if ( !g_param_libyt.get_gridsPtr ){
-      YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// check if user has call yt_commit_grids(), so that grids are appended to YT.
-   if ( !g_param_libyt.commit_grids ){
-      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// Not sure if we need this MPI_Barrier
-   MPI_Barrier(MPI_COMM_WORLD);
-
 
    return YT_SUCCESS;
 }

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -59,7 +59,6 @@ int yt_inline()
    free( CallYT );
 
 
-// TODO: Check the resources should be freed!!!
 // free resources to prepare for the next execution
    g_param_libyt.param_yt_set = false;
    g_param_libyt.get_gridsPtr = false;

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -39,9 +39,9 @@ int yt_inline()
    if ( !g_param_libyt.get_gridsPtr )
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
 
-// check if user has call yt_add_grids(), so that grids are appended to YT.
+// check if user has call yt_commit_grids(), so that grids are appended to YT.
    if ( !g_param_libyt.add_grids )
-      YT_ABORT( "Please invoke yt_add_grids() before calling %s()!\n", __FUNCTION__ );
+      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
 
 // Not sure if we need this MPI_Barrier
    MPI_Barrier(MPI_COMM_WORLD);

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -40,7 +40,7 @@ int yt_inline()
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
 
 // check if user has call yt_commit_grids(), so that grids are appended to YT.
-   if ( !g_param_libyt.add_grids )
+   if ( !g_param_libyt.commit_grids )
       YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
 
 // Not sure if we need this MPI_Barrier
@@ -64,7 +64,7 @@ int yt_inline()
 // free resources to prepare for the next execution
    g_param_libyt.param_yt_set = false;
    g_param_libyt.get_gridsPtr = false;
-   g_param_libyt.add_grids    = false;
+   g_param_libyt.commit_grids    = false;
    g_param_libyt.counter ++;
 
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -47,9 +47,11 @@ int yt_inline()
    MPI_Barrier(MPI_COMM_WORLD);
 
 // execute YT script
-   const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + 13;   // 13 = ".yt_inline()" + '\0'
+// TODO: Change the execute function name to arbitrary
+   int InlineFunctionWidth = strlen(g_param_yt.inline_function_name) + 4; // width = .<function_name>() + '\0'
+   const int CallYT_CommandWidth = strlen( g_param_libyt.script ) + InlineFunctionWidth;
    char *CallYT = (char*) malloc( CallYT_CommandWidth*sizeof(char) );
-   sprintf( CallYT, "%s.yt_inline()", g_param_libyt.script );
+   sprintf( CallYT, "%s.%s()", g_param_libyt.script, g_param_yt.inline_function_name );
 
    if ( PyRun_SimpleString( CallYT ) == 0 )
       log_debug( "Invoking \"%s\" ... done\n", CallYT );

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -19,25 +19,29 @@ int yt_inline( char *function_name )
 {
 
 // check if libyt has been initialized
-   if ( g_param_libyt.libyt_initialized )
-      log_info( "Performing YT inline analysis ...\n" );
-   else
+   if ( !g_param_libyt.libyt_initialized ){
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // check if YT parameters have been set
-   if ( !g_param_libyt.param_yt_set )
+   if ( !g_param_libyt.param_yt_set ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
-   if ( !g_param_libyt.get_gridsPtr )
+   if ( !g_param_libyt.get_gridsPtr ){
       YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // check if user has call yt_commit_grids(), so that grids are appended to YT.
-   if ( !g_param_libyt.commit_grids )
+   if ( !g_param_libyt.commit_grids ){
       YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
+   }
 
 // Not sure if we need this MPI_Barrier
    MPI_Barrier(MPI_COMM_WORLD);
+
+   log_info( "Performing YT inline analysis ...\n" );
 
 // execute function in python script
    int InlineFunctionWidth = strlen(function_name) + 4; // width = .<function_name>() + '\0'
@@ -51,6 +55,8 @@ int yt_inline( char *function_name )
       YT_ABORT(  "Invoking \"%s\" ... failed\n", CallYT );
 
    free( CallYT );
+
+   log_info( "Performing YT inline analysis ... done.\n" );
 
    return YT_SUCCESS;
 

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -66,6 +66,9 @@ int yt_inline()
    g_param_libyt.add_grids    = false;
    g_param_libyt.counter ++;
 
+   for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
+      delete [] g_param_yt.grids_local[i].field_data;
+   }
    delete [] g_param_yt.grids_local;
    delete [] g_param_yt.num_grids_local_MPI;
    g_param_yt.init();

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -87,8 +87,8 @@ int yt_inline( char *function_name, int argc, ... ){
       }
       strcat( CallYT, ")");
 
-      // DEBUG:
-      printf("#FLAG, %s\n", CallYT);
+      va_end(Args_len);
+      va_end(Args);
 
       if ( PyRun_SimpleString( CallYT ) == 0 ){
          log_debug( "Invoking \"%s\" ... done\n", CallYT );

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -69,6 +69,11 @@ int yt_set_parameter( yt_param_yt *param_yt )
       g_param_yt.fig_basename = fig_basename;
    }
 
+// set the default execute python function name if it's not set by users
+   if ( param_yt->inline_function_name == NULL ){
+      g_param_yt.inline_function_name = "yt_inline";
+   }
+
 
 // export data to libyt.param_yt
 // strings

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -95,6 +95,7 @@ int yt_set_parameter( yt_param_yt *param_yt )
    add_dict_scalar(  g_py_param_yt, "length_unit",             g_param_yt.length_unit             );
    add_dict_scalar(  g_py_param_yt, "mass_unit",               g_param_yt.mass_unit               );
    add_dict_scalar(  g_py_param_yt, "time_unit",               g_param_yt.time_unit               );
+   add_dict_scalar(  g_py_param_yt, "magnetic_unit",           g_param_yt.magnetic_unit           );
    add_dict_scalar(  g_py_param_yt, "cosmological_simulation", g_param_yt.cosmological_simulation );
    add_dict_scalar(  g_py_param_yt, "dimensionality",          g_param_yt.dimensionality          );
    add_dict_scalar(  g_py_param_yt, "refine_by",               g_param_yt.refine_by               );

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -60,11 +60,18 @@ int yt_set_parameter( yt_param_yt *param_yt )
    g_param_yt = *param_yt;
 
 
-// set the default figure base name if it's not set by users
+// set the default figure base name if it's not set by users.
    if ( param_yt->fig_basename == NULL )
    {
       char fig_basename[15];
       sprintf( fig_basename, "Fig%09ld", g_param_libyt.counter );
+
+      g_param_yt.fig_basename = fig_basename;
+   }
+// append g_param_libyt.counter to prevent over-written
+   else {
+      char fig_basename[1000];
+      sprintf( fig_basename, "%s%09ld", param_yt->fig_basename, g_param_libyt.counter );
 
       g_param_yt.fig_basename = fig_basename;
    }

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -76,12 +76,6 @@ int yt_set_parameter( yt_param_yt *param_yt )
       g_param_yt.fig_basename = fig_basename;
    }
 
-// set the default execute python function name if it's not set by users
-   if ( param_yt->inline_function_name == NULL ){
-      g_param_yt.inline_function_name = "yt_inline";
-   }
-
-
 // export data to libyt.param_yt
 // strings
    add_dict_string(  g_py_param_yt, "frontend",                g_param_yt.frontend                );

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -155,7 +155,7 @@ int yt_set_parameter( yt_param_yt *param_yt )
    }
 
    // Gather num_grids_local in every rank and store at num_grids_local_MPI, with "MPI_Gather"
-   // We need num_grids_local_MPI in MPI_Gatherv in yt_add_grids()
+   // We need num_grids_local_MPI in MPI_Gatherv in yt_commit_grids()
    int NRank;
    int RootRank = 0;
    MPI_Comm_size(MPI_COMM_WORLD, &NRank);

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -53,6 +53,7 @@ int yt_set_parameter( yt_param_yt *param_yt )
    else
       YT_ABORT(  "Validating YT parameters ... failed\n" );
 
+// TODO: check if yt_field field_list has all the field_name unique
 
 // print out all parameters
    log_debug( "List of YT parameters:\n" );

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -53,7 +53,6 @@ int yt_set_parameter( yt_param_yt *param_yt )
    else
       YT_ABORT(  "Validating YT parameters ... failed\n" );
 
-// TODO: check if yt_field field_list has all the field_name unique
 
 // print out all parameters
    log_debug( "List of YT parameters:\n" );
@@ -107,9 +106,6 @@ int yt_set_parameter( yt_param_yt *param_yt )
    add_dict_vector3( g_py_param_yt, "domain_right_edge",       g_param_yt.domain_right_edge       );
    add_dict_vector3( g_py_param_yt, "periodicity",             g_param_yt.periodicity             );
    add_dict_vector3( g_py_param_yt, "domain_dimensions",       g_param_yt.domain_dimensions       );
-
-// add field_list as dictionary
-   add_dict_field_list();
 
    log_debug( "Inserting YT parameters to libyt.param_yt ... done\n" );
 

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -107,6 +107,9 @@ int yt_set_parameter( yt_param_yt *param_yt )
    add_dict_vector3( g_py_param_yt, "periodicity",             g_param_yt.periodicity             );
    add_dict_vector3( g_py_param_yt, "domain_dimensions",       g_param_yt.domain_dimensions       );
 
+// add field_list as dictionary
+   add_dict_field_list();
+
    log_debug( "Inserting YT parameters to libyt.param_yt ... done\n" );
 
 

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -23,11 +23,16 @@ int yt_set_parameter( yt_param_yt *param_yt )
 {
 
 // check if libyt has been initialized
-   if ( g_param_libyt.libyt_initialized )
-      log_info( "Setting YT parameters ...\n" );
-   else
+   if ( !g_param_libyt.libyt_initialized ){
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
+   }
 
+// check if libyt has free all the resource in previous inline-analysis
+   if ( !g_param_libyt.free_gridsPtr ){
+      YT_ABORT( "Please invoke yt_free_gridsPtr() before calling %s() for next iteration!\n", __FUNCTION__ );
+   }
+
+   log_info( "Setting YT parameters ...\n" );
 
 // check if this function has been called previously
    if ( g_param_libyt.param_yt_set )
@@ -170,7 +175,9 @@ int yt_set_parameter( yt_param_yt *param_yt )
    }
 
 // If the above all works like charm.
-   g_param_libyt.param_yt_set = true;
+   g_param_libyt.param_yt_set  = true;
+   g_param_libyt.free_gridsPtr = false;
+   log_info( "Setting YT parameters ... done.\n" );
 
    return YT_SUCCESS;
 


### PR DESCRIPTION
Support new features:

- [x] Work with `python3.8`
- [x] Simulation code can use `libyt` to run parallel inline-analysis with `yt`.
- [x] Make user input their own derived function
  * For example, convert `face-centered` magnetic fields to `cell-centered` data when `yt` needs them. This can save memory.