### PR TITLE
Support Particle Operation and Other Miscellaneous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ example/example
 stderr
 stdout
 lib/*
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,3 @@
 libyt.so.1.*
 example/example
 
-.idea/*
-*.png
-stderr
-stdout
-lib/*
-Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 *.pyc
 libyt.so.1.*
 example/example
+
+.idea/*
+*.png
+stderr
+stdout
+lib/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.pyc
 libyt.so.1.*
 example/example
-

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -282,8 +282,6 @@ int main( int argc, char *argv[] )
             sim_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
 
-         sim_grids[gid].particle_count_list[0] = 1;      // Fill in the number of particles of the species in this grid.
-                                                         // Be careful that the order should be the same as particle_list.
          sim_grids[gid].id                     = gid;    // 0-indexed
          sim_grids[gid].parent_id              = -1;     // 0-indexed (-1 for grids on the root level)
          sim_grids[gid].level                  = 0;      // 0-indexed
@@ -329,8 +327,7 @@ int main( int argc, char *argv[] )
             sim_grids[gid].right_edge[d] = sim_grids[gid].left_edge[d] + GRID_DIM*dh1;
             sim_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
-         sim_grids[gid].particle_count_list[0] = 1;      // Fill in the number of particles of the species in this grid.
-                                                         // Be careful that the order should be the same as particle_list.
+
          sim_grids[gid].id             = gid;          // 0-indexed
          sim_grids[gid].parent_id      = gid_refine;   // 0-indexed (-1 for grids on the root level)
          sim_grids[gid].level          = 1;            // 0-indexed
@@ -382,7 +379,7 @@ int main( int argc, char *argv[] )
                grids_local[index_local].right_edge[d] = sim_grids[gid].right_edge[d];
                grids_local[index_local].grid_dimensions[d] = sim_grids[gid].grid_dimensions[d];
             }
-            grids_local[index_local].particle_count_list[0] = sim_grids[gid].particle_count_list[0];
+            grids_local[index_local].particle_count_list[0] = 1; // set the num of particle in species.
             grids_local[index_local].id             = sim_grids[gid].id;
             grids_local[index_local].parent_id      = sim_grids[gid].parent_id;
             grids_local[index_local].level          = sim_grids[gid].level;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -282,10 +282,11 @@ int main( int argc, char *argv[] )
             sim_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
 
-         sim_grids[gid].particle_count = 1;      // particles are not supported yet
-         sim_grids[gid].id             = gid;    // 0-indexed
-         sim_grids[gid].parent_id      = -1;     // 0-indexed (-1 for grids on the root level)
-         sim_grids[gid].level          = 0;      // 0-indexed
+         sim_grids[gid].particle_count_list[0] = 1;      // Fill in the number of particles of the species in this grid.
+                                                         // Be careful that the order should be the same as particle_list.
+         sim_grids[gid].id                     = gid;    // 0-indexed
+         sim_grids[gid].parent_id              = -1;     // 0-indexed (-1 for grids on the root level)
+         sim_grids[gid].level                  = 0;      // 0-indexed
 
 //       in this example we arbitrarily set the field data of this grid
          for (int k=0; k<GRID_DIM; k++)
@@ -328,8 +329,8 @@ int main( int argc, char *argv[] )
             sim_grids[gid].right_edge[d] = sim_grids[gid].left_edge[d] + GRID_DIM*dh1;
             sim_grids[gid].grid_dimensions[d] = GRID_DIM;   // this example assumes cubic grids
          }
-
-         sim_grids[gid].particle_count = 1;            // particles are not supported yet
+         sim_grids[gid].particle_count_list[0] = 1;      // Fill in the number of particles of the species in this grid.
+                                                         // Be careful that the order should be the same as particle_list.
          sim_grids[gid].id             = gid;          // 0-indexed
          sim_grids[gid].parent_id      = gid_refine;   // 0-indexed (-1 for grids on the root level)
          sim_grids[gid].level          = 1;            // 0-indexed
@@ -381,7 +382,7 @@ int main( int argc, char *argv[] )
                grids_local[index_local].right_edge[d] = sim_grids[gid].right_edge[d];
                grids_local[index_local].grid_dimensions[d] = sim_grids[gid].grid_dimensions[d];
             }
-            grids_local[index_local].particle_count = sim_grids[gid].particle_count;
+            grids_local[index_local].particle_count_list[0] = sim_grids[gid].particle_count_list[0];
             grids_local[index_local].id             = sim_grids[gid].id;
             grids_local[index_local].parent_id      = sim_grids[gid].parent_id;
             grids_local[index_local].level          = sim_grids[gid].level;

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -44,7 +44,7 @@ void get_randArray(int *array, int length);
 void par_io_get_attr(long gid, char *attribute, void *data);   // Must have for yt to get particle's attribute.
                                                                // One particle type need to setup one get_attr.
 void getPositionByGID( long gid, real (*Pos)[3] );  // These function is for getting particle position and level info.
-void getLevelByGID( long gid, int *Level );
+void getLevelByGID( long gid, int *Level );         // Used by par_io_get_attr.
 yt_grid *gridsPtr;
 long     num_total_grids;
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -99,11 +99,13 @@ int main( int argc, char *argv[] )
    const double dh1         = dh0 / REFINE_BY;                  // cell size at level 1
    const int    num_fields  = 1;                                // number of fields
    const int    num_grids   = CUBE(NGRID_1D)+CUBE(REFINE_BY);   // number of grids
-   const int    num_species = 1;                                // number of particle species
+   const int    num_species = 2;                                // number of particle species
    yt_species  *species_list = new yt_species [num_species];    // define species list, so that libyt knows particle species name,
                                                                 // and their number of attribute in each of them.
    species_list[0].species_name = "io";                         // particle species "io", with 4 attributes
    species_list[0].num_attr     = 4;
+   species_list[1].species_name = "par2";
+   species_list[1].num_attr     = 4;
    
    int *grids_MPI = new int [num_grids];                        // Record MPI rank in each grids
 
@@ -225,8 +227,9 @@ int main( int argc, char *argv[] )
 //    Be careful that the order you filled in particle_list, should be the same yt_species *species_list.
       particle_list[0].species_name = "io";     // This two line is redundant, since libyt has already filled in.
       particle_list[0].num_attr     = 4;        // I type it here just to make things clear.
-      
+
       char     *attr_name[]  = {"ParPosX", "ParPosY", "ParPosZ", "Level"}; // Attribute name
+      char     *attr_name_alias[] = {"grid_level"};                        // Alias name for attribute level
       for ( int v=0; v < 4; v++ ){
          
          particle_list[0].attr_list[v].attr_name  = attr_name[v];    // Must fill in attribute name.
@@ -235,9 +238,8 @@ int main( int argc, char *argv[] )
             particle_list[0].attr_list[v].attr_dtype = YT_INT;       // Must fill in attribute data type.
             particle_list[0].attr_list[v].attr_unit  = "";           // [Optional] if not filled in, libyt will use XXXFieldInfo 
                                                                      // set by param_yt.frontend if it exists.
-            // particle_list[0].attr_list[v].num_attr_name_alias = 1;   // [Optional] set name alias of this attribute.
-            // char *attr_name_alias[] = {"grid_level"};
-            // particle_list[0].attr_list[v].attr_name_alias     = attr_name_alias;
+            particle_list[0].attr_list[v].num_attr_name_alias = 1;   // [Optional] set name alias of this attribute.
+            particle_list[0].attr_list[v].attr_name_alias     = attr_name_alias;
             particle_list[0].attr_list[v].attr_display_name   = "Level of the Grid"; // [Optional] if not fill in, libyt will 
                                                                                      // display attr_name. 
          }   
@@ -252,6 +254,10 @@ int main( int argc, char *argv[] )
 
       particle_list[0].get_attr = par_io_get_attr;   // par_io_get_attr is a function ptr that takes arguments (long, char* void*)
                                                      // and returns void.
+
+      for ( int v=0; v<4; v++ ){
+         particle_list[1].attr_list[v].attr_name = attr_name[v];     // Fill in for particle species "par2"
+      }
 
 //    ============================================================
 //    5. Get pointer to local grids array, then set up local grids

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -574,7 +574,6 @@ void getLevelByGID( long gid, int *Level ){
    for ( long i = 0; i < num_total_grids; i++ ){
       if ( gridsPtr[i].id == gid ){
          *Level = gridsPtr[i].level;
-         printf("LEVEL = %d\n", gridsPtr[i].level);
          break;
       }
    }

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -15,11 +15,14 @@ def yt_inline_ProjectionPlot( fields ):
     if yt.is_root():
         prjz.save()
     
-def yt_inline_ProfilePlot():
+def yt_inline_ParticlePlot():
+    # YT Particle Plot does not support parallelism for now
+    # So we run mpirun -np 1
     ds = yt.frontends.libyt.libytDataset()
-    profile = yt.ProfilePlot(ds, "x", ["density"])
+    
+    par = yt.ParticleProjectionPlot(ds, "z")
 
-    if yt.is_root():
+    par.save()
         profile.save()
 
 def test_user_parameter():

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -20,10 +20,15 @@ def yt_inline_ParticlePlot():
     # So we run mpirun -np 1
     ds = yt.frontends.libyt.libytDataset()
     
-    par = yt.ParticleProjectionPlot(ds, "z")
+    ## ParticleProjectionPlot
+    #==========================
+    # par = yt.ParticleProjectionPlot(ds, "z")
+
+    ## ParticlePlot
+    #==========================
+    par = yt.ParticlePlot(ds, "particle_position_x", "particle_position_y", "Level", center = 'c')
 
     par.save()
-        profile.save()
 
 def test_user_parameter():
     import libyt

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -27,6 +27,7 @@ int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt );
 int yt_finalize();
 int yt_set_parameter( yt_param_yt *param_yt );
 int yt_get_fieldsPtr( yt_field **field_list );
+int yt_get_particlesPtr( yt_particle **particle_list );
 int yt_get_gridsPtr( yt_grid **grids_local );
 int yt_add_user_parameter_int   ( const char *key, const int n, const int    *input );
 int yt_add_user_parameter_long  ( const char *key, const int n, const long   *input );

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -13,7 +13,7 @@
 // Data Member :  dimensions     : Number of cells along each direction
 //                left_edge      : Grid left  edge in code units
 //                right_edge     : Grid right edge in code units
-//                particle_count : Nunber of particles in this grid
+//                grid_particle_count : Nunber of total particles in this grid
 //                level          : AMR level (0 for the root level)
 //                proc_num       : An array of MPI rank that the grid belongs
 //                id             : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
@@ -24,7 +24,7 @@ struct yt_hierarchy{
       double left_edge[3];
       double right_edge[3];
 
-      long   particle_count;
+      long   grid_particle_count;
       long   id;
       long   parent_id;
 

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -51,6 +51,7 @@ int  add_dict_vector3( PyObject *dict, const char *key, const T *vector );
 int  add_dict_string( PyObject *dict, const char *key, const char *string );
 
 int  add_dict_field_list( );
+int  add_dict_particle_list( );
 #endif
 
 

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -6,6 +6,33 @@
 // include relevant headers
 #include "yt_type.h"
 
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_hierarchy
+// Description :  Data structure for pass hierarchy of the grid in MPI process, it is meant to be temperary.
+//
+// Data Member :  dimensions     : Number of cells along each direction
+//                left_edge      : Grid left  edge in code units
+//                right_edge     : Grid right edge in code units
+//                particle_count : Nunber of particles in this grid
+//                level          : AMR level (0 for the root level)
+//                proc_num       : An array of MPI rank that the grid belongs
+//                id             : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
+//                parent_id      : Parent grid ID (0-indexed, -1 for grids on the root level)
+//                proc_num       : Process number, grid belong to which MPI rank
+//-------------------------------------------------------------------------------------------------------
+struct yt_hierarchy{
+      double left_edge[3];
+      double right_edge[3];
+
+      long   particle_count;
+      long   id;
+      long   parent_id;
+
+      int    dimensions[3];
+      int    level;
+      int    proc_num;
+};
+
 void log_info   ( const char *Format, ... );
 void log_warning( const char *format, ... );
 void log_debug  ( const char *Format, ... );

--- a/include/yt_type.h
+++ b/include/yt_type.h
@@ -26,31 +26,5 @@ enum yt_ftype   { YT_FTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2 };
 #include "yt_type_grid.h"
 #include "yt_type_field.h"
 
-//-------------------------------------------------------------------------------------------------------
-// Structure   :  yt_hierarchy
-// Description :  Data structure for pass hierarchy of the grid in MPI process, it is meant to be temperary.
-//
-// Data Member :  dimensions     : Number of cells along each direction
-//                left_edge      : Grid left  edge in code units
-//                right_edge     : Grid right edge in code units
-//                particle_count : Nunber of particles in this grid
-//                level          : AMR level (0 for the root level)
-//                proc_num       : An array of MPI rank that the grid belongs
-//                id             : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
-//                parent_id      : Parent grid ID (0-indexed, -1 for grids on the root level)
-//                proc_num       : Process number, grid belong to which MPI rank
-//-------------------------------------------------------------------------------------------------------
-struct yt_hierarchy{
-      double left_edge[3];
-      double right_edge[3];
-
-      long   particle_count;
-      long   id;
-      long   parent_id;
-
-      int    dimensions[3];
-      int    level;
-      int    proc_num;
-};
 
 #endif // #ifndef __YT_TYPE_H__

--- a/include/yt_type.h
+++ b/include/yt_type.h
@@ -17,7 +17,7 @@ typedef unsigned long int  ulong;
 
 // enumerate types
 enum yt_verbose { YT_VERBOSE_OFF=0, YT_VERBOSE_INFO=1, YT_VERBOSE_WARNING=2, YT_VERBOSE_DEBUG=3 };
-enum yt_ftype   { YT_FTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2 };
+enum yt_ftype   { YT_FTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2, YT_INT=3 };
 
 
 // structures
@@ -25,6 +25,7 @@ enum yt_ftype   { YT_FTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2 };
 #include "yt_type_param_yt.h"
 #include "yt_type_grid.h"
 #include "yt_type_field.h"
+#include "yt_type_particle.h"
 
 
 #endif // #ifndef __YT_TYPE_H__

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -20,7 +20,7 @@ void log_warning(const char *Format, ...);
 // 
 // Notes       :  1. The data representation type will be initialize as "cell-centered".
 //                2. "field_unit", "field_name_alias", "field_display_name", are set corresponding to yt 
-//                   ( "name", ("units", ["fields", "to", "alias"], # "display_name"))
+//                   ( "name", ("units", ["fields", "to", "alias"], "display_name"))
 //
 // Data Member :  char  *field_name           : Field name
 //                char  *field_define_type    : Define type, for now, we have these types, define in 
@@ -36,7 +36,8 @@ void log_warning(const char *Format, ...);
 //                char  *field_display_name   : Set display name on the plottings, if not set, yt will 
 //                                              use field_name as display name.
 //
-//                (func pointer) derived_func : pointer to function that has argument (int, double *)
+//                (func pointer) derived_func : pointer to function that has argument (long, double *)
+//                                              and no return.
 //
 // Method      :  yt_field  : Constructor
 //               ~yt_field  : Destructor
@@ -63,7 +64,9 @@ struct yt_field
 // Description : Constructor of the structure "yt_field"
 // 
 // Note        : 1. Initialize field_define_type as "cell-centered"
-// 
+//               2. Initialize attr_unit as "NOT SET", if it is not set by user, then yt will use the 
+//                  particle unit set by the frontend in yt_set_parameter(). If there still isn't one,
+//                  then it will display "NOT SET" in graph. 
 // Parameter   : None
 // ======================================================================================================
 	yt_field()
@@ -109,7 +112,6 @@ struct yt_field
    	// field name is set.
    	if ( field_name == NULL ){
    		YT_ABORT("field_name is not set!\n");
-   		return YT_FAIL;
    	}
 
    	// field_define_type can only be : "cell-centered", "face-centered", "derived_func".
@@ -124,7 +126,6 @@ struct yt_field
    	}
    	if ( check1 == false ){
    		YT_ABORT("In field [%s], unknown field_define_type [%s]!\n", field_name, field_define_type);
-   		return YT_FAIL;
    	}
 
    	// Raise warning if derived_func == NULL and field_define_type is set to "derived_func".

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -64,9 +64,9 @@ struct yt_field
 // Description : Constructor of the structure "yt_field"
 // 
 // Note        : 1. Initialize field_define_type as "cell-centered"
-//               2. Initialize attr_unit as "NOT SET", if it is not set by user, then yt will use the 
-//                  particle unit set by the frontend in yt_set_parameter(). If there still isn't one,
-//                  then it will display "NOT SET" in graph. 
+//               2. Initialize field_unit as "". If it is not set by user, then yt will use the particle 
+//                  unit set by the frontend in yt_set_parameter(). If there still isn't one, then it 
+//                  will use "". 
 // Parameter   : None
 // ======================================================================================================
 	yt_field()

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -74,7 +74,7 @@ struct yt_field
 		field_name = NULL;
 		field_define_type = "cell-centered";
 		swap_axes = true;
-		field_unit = "NOT SET";
+		field_unit = "";
 		num_field_name_alias = 0;
 		field_name_alias = NULL;
 		field_display_name = NULL;

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -37,7 +37,11 @@ struct yt_data
 // Data Member :  grid_dimensions : Number of cells along each direction in [x][y][z] coordinate.
 //                left_edge       : Grid left  edge in code units
 //                right_edge      : Grid right edge in code units
-//                particle_count  : Nunber of particles in this grid
+//                particle_count_list : Array that records number of particles in each species, the input order
+//                                      should be the same as the input particle_list.
+//                grid_particle_count : Number of particles in this grid, which is sum of the particle_count array.
+//                                      This will be filled in by libyt, user don't need to touch this. They should
+//                                      only fill in particle_count_list.
 //                level           : AMR level (0 for the root level)
 //                id              : Grid ID (0-indexed ==> must be in the range 0 <= id < total number of grids)
 //                parent_id       : Parent grid ID (0-indexed, -1 for grids on the root level)
@@ -57,7 +61,8 @@ struct yt_grid
    double    left_edge[3];
    double    right_edge[3];
 
-   long      particle_count;
+   long     *particle_count_list;
+   long      grid_particle_count;
    long      id;
    long      parent_id;
 
@@ -86,7 +91,8 @@ struct yt_grid
       for (int d=0; d<3; d++) {
       grid_dimensions[d]  = INT_UNDEFINED; }
 
-      particle_count = LNG_UNDEFINED;
+      grid_particle_count = 0;
+      particle_count_list = NULL;
       id             = LNG_UNDEFINED;
       parent_id      = LNG_UNDEFINED;
       level          = INT_UNDEFINED;
@@ -136,7 +142,6 @@ struct yt_grid
 
       for (int d=0; d<3; d++) {
       if ( grid_dimensions[d]  == INT_UNDEFINED )   YT_ABORT( "\"%s[%d]\" has not been set for grid id [%ld]!\n", "grid_dimensions", d,  id ); }
-      if ( particle_count == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "particle_count", id );
       if ( id             == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "id",             id );
       if ( parent_id      == LNG_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "parent_id",      id );
       if ( level          == INT_UNDEFINED    )   YT_ABORT(     "\"%s\" has not been set for grid id [%ld]!\n", "level",          id );
@@ -146,7 +151,6 @@ struct yt_grid
 //    additional checks
       for (int d=0; d<3; d++) {
       if ( grid_dimensions[d] <= 0 )   YT_ABORT( "\"%s[%d]\" == %d <= 0 for grid [%ld]!\n", "grid_dimensions", d, grid_dimensions[d], id ); }
-      if ( particle_count < 0 )   YT_ABORT( "\"%s\" == %d < 0 for grid [%ld]!\n", "particle_count", particle_count, id );
       if ( id < 0 )               YT_ABORT( "\"%s\" == %d < 0!\n", "id", id );
       if ( level < 0 )            YT_ABORT( "\"%s\" == %d < 0 for grid [%ld]!\n", "level", level, id );
 

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -24,6 +24,7 @@
 //                libyt_initialized           : true ==> yt_init() has been called successfully
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_fieldsPtr               : true ==> yt_get_fieldsPtr() has been called successfully
+//                get_particlePtr             : true ==> yt_get_particlesPtr() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
 //                commit_grids                : true ==> yt_commit_grids() has been called successfully
 //                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, 
@@ -46,6 +47,7 @@ struct yt_param_libyt
    bool  libyt_initialized;
    bool  param_yt_set;
    bool  get_fieldsPtr;
+   bool  get_particlesPtr;
    bool  get_gridsPtr;
    bool  commit_grids;
    bool  free_gridsPtr;
@@ -70,6 +72,7 @@ struct yt_param_libyt
       libyt_initialized  = false;
       param_yt_set       = false;
       get_fieldsPtr      = false;
+      get_particlesPtr   = false;
       get_gridsPtr       = false;
       commit_grids       = false;
       free_gridsPtr      = true;

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -24,7 +24,7 @@
 //                libyt_initialized           : true ==> yt_init() has been called successfully
 //                param_yt_set                : true ==> yt_set_parameter() has been called successfully
 //                get_fieldsPtr               : true ==> yt_get_fieldsPtr() has been called successfully
-//                get_particlePtr             : true ==> yt_get_particlesPtr() has been called successfully
+//                get_particlesPtr            : true ==> yt_get_particlesPtr() has been called successfully
 //                get_gridsPtr                : true ==> yt_get_gridsPtr() has been called successfully
 //                commit_grids                : true ==> yt_commit_grids() has been called successfully
 //                free_gridsPtr               : true ==> yt_free_gridsPtr() has been called successfully, 

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -51,7 +51,8 @@ void log_warning(const char *Format, ...);
 //                grids_MPI               : grids belongs to which MPI rank
 //                num_grids_local         : Number of local grids in each rank
 //                field_list              : field list, including {field_name, field_define_type, field_unit ,...}
-//                particle_list           : particle list, including {species_name, attr_list, ...}, pointer
+//                particle_list           : particle list, including {species_name, attr_list, ...}
+//                species_list            : species list of particles, includeing {species_name, num_attr}
 //                grids_local             : Ptr to full information of local grids
 //                field_ftype             : Floating-point type of "field_data" ==> YT_FLOAT or YT_DOUBLE
 //

--- a/include/yt_type_param_yt.h
+++ b/include/yt_type_param_yt.h
@@ -232,6 +232,9 @@ struct yt_param_yt
       if ( refine_by               == INT_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "refine_by" );
       if ( num_grids               == LNG_UNDEFINED )   YT_ABORT( "\"%s\" has not been set!\n",     "num_grids" );
       if ( num_species > 0 && species_list == NULL  )   YT_ABORT( "Particle species info species_list and num_species have not been set!\n");
+      for (int s=0; s<num_species; s++) {
+      if ( species_list[s].species_name == NULL || species_list[s].num_attr < 0 ) YT_ABORT( "species_list element [ %d ] is not set properly!\n", s);
+      }
       if ( grids_MPI == NULL && num_grids_local == INT_UNDEFINED )  YT_ABORT( "Either grids_MPI or num_grids_local should be set!\n");
       if ( field_ftype != YT_FLOAT  &&  field_ftype != YT_DOUBLE )  YT_ABORT( "Unknown \"%s\" == %d !\n", "field_ftype", field_ftype);
 

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -71,9 +71,9 @@ struct yt_attribute
 // Method      : yt_attribute
 // Description : Constructor of the structure "yt_attribute"
 // 
-// Note        : 1. Initialize attr_unit as "NOT SET", if it is not set by user, then yt will use the 
-//                  attribute unit set by the frontend in yt_set_parameter(). If there still isn't one,
-//                  then it will display "NOT SET" in graph.
+// Note        : 1. Initialize attr_unit as "". If it is not set by user, then yt will use the particle 
+//                  unit set by the frontend in yt_set_parameter(). If there still isn't one, then it 
+//                  will use "". 
 //               2. Initialize attr_dtype as YT_DOUBLE.
 // 
 // Parameter   : None

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -242,17 +242,17 @@ struct yt_particle
 
    		// attr_list != NULL
    		if ( attr_list == NULL ){
-   			YT_ABORT("attr_list not set properly!\n");
+   			YT_ABORT("In particle species [ %s ], attr_list not set properly!\n", species_name);
    		}
 		// num_attr should > 0
    		if ( num_attr < 0 ){
-   			YT_ABORT("num_attr not set properly!\n");
+   			YT_ABORT("In particle species [ %s ], num_attr not set properly!\n", species_name);
    		}
    		
    		// call yt_attribute validate for each attr_list elements.
    		for ( int i = 0; i < num_attr; i++ ){
    			if ( !(attr_list[i].validate()) ){
-   				YT_ABORT("attr_list element [ %d ] not set properly!\n", i);
+   				YT_ABORT("In particle species [ %s ], attr_list element [ %d ] not set properly!\n", species_name, i);
    			}
    		}
 
@@ -268,18 +268,18 @@ struct yt_particle
 
    		// if didn't input coor_x/y/z, yt cannot function properly for this particle.
    		if ( coor_x == NULL ){
-   			log_warning("Attribute name of coordinate x coor_x not set!\n");
+   			log_warning("In particle species [ %s ], attribute name of coordinate x coor_x not set!\n", species_name);
    		}
    		if ( coor_y == NULL ){
-   			log_warning("Attribute name of coordinate y coor_y not set!\n");
+   			log_warning("In particle species [ %s ], attribute name of coordinate y coor_y not set!\n", species_name);
    		}
    		if ( coor_z == NULL ){
-   			log_warning("Attribute name of coordinate z coor_z not set!\n");
+   			log_warning("In particle species [ %s ], attribute name of coordinate z coor_z not set!\n", species_name);
    		}
 
    		// if didn't input get_attr, yt cannot function properly for this particle.
    		if ( get_attr == NULL ){
-   			log_warning("Function that gets particle attribute get_attr not set!\n");
+   			log_warning("In particle species [ %s ], function that gets particle attribute get_attr not set!\n", species_name);
    		}
 
       	return YT_SUCCESS;

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -1,0 +1,297 @@
+#ifndef __YT_TYPE_PARTICLE_H__
+#define __YT_TYPE_PARTICLE_H__
+
+/*******************************************************************************
+/
+/  yt_species, yt_attribute, and yt_particle structure
+/
+/  ==> included by yt_type.h
+/
+********************************************************************************/
+
+#include <string.h>
+void log_debug( const char *Format, ... );
+void log_warning(const char *Format, ...);
+
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_species
+// Description :  Data structure to store each species names and their number of attributes.
+// 
+// Notes       :  1. Some data are overlap with yt_particle. We need this first be input by user through
+//                   yt_set_parameter(), so that we can setup and initialize particle_list properly.
+//
+// Data Member :  char  *species_name  : Particle species name, which in yt, it is ptype.
+//                int    num_attr      : Number of attributes in this species.
+//-------------------------------------------------------------------------------------------------------
+struct yt_species
+{
+	char *species_name;
+	int   num_attr;
+};
+
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_attribute
+// Description :  Data structure to store particle attributes.
+// 
+// Notes       :  1. "attr_unit", "attr_name_alias", "attr_display_name", are set corresponding to yt 
+//                   ( "name", ("units", ["alias1", "alias2"], "display_name"))
+//
+// Data Member :  char     *attr_name             : Particle label name, which in yt, it is its attribute.
+//                yt_ftype  attr_dtype            : Attribute's data type. For now, it is type yt_ftype:
+//                                                  (1) YT_FLOAT (2) YT_DOUBLE (3) YT_INT
+//                char     *attr_unit             : Set attr_unit if needed, if not set, it will search 
+//                                               for XXXFieldInfo. Where XXX is set by g_param_yt.frontend.
+//                int       num_attr_name_alias   : Set attribute name to alias, number of the aliases.
+//                char    **attr_name_alias       : Aliases.
+//                char     *attr_display_name     : Set display name on the plottings, if not set, yt will 
+//                                                  use attr_name as display name.
+//
+// Method      :  yt_attribute  : Constructor
+//               ~yt_attribute  : Destructor
+//                show          : Print data member value
+//                validate      : Validate data member in struct
+//-------------------------------------------------------------------------------------------------------
+struct yt_attribute
+{
+	char     *attr_name;
+	yt_ftype  attr_dtype;
+	char     *attr_unit;
+	int       num_attr_name_alias;
+	char    **attr_name_alias;
+	char     *attr_display_name;
+
+
+//=======================================================================================================
+// Method      : yt_attribute
+// Description : Constructor of the structure "yt_attribute"
+// 
+// Note        : 1. Initialize attr_unit as "NOT SET", if it is not set by user, then yt will use the 
+//                  attribute unit set by the frontend in yt_set_parameter(). If there still isn't one,
+//                  then it will display "NOT SET" in graph.
+//               2. Initialize attr_dtype as YT_DOUBLE.
+// 
+// Parameter   : None
+// ======================================================================================================
+	yt_attribute()
+	{
+		attr_name = NULL;
+		attr_dtype = YT_DOUBLE;
+		attr_unit = "NOT SET";
+		num_attr_name_alias = 0;
+		attr_name_alias = NULL;
+		attr_display_name = NULL;
+	} // METHOD : yt_attribute
+
+
+//=======================================================================================================
+// Method      : show
+// Description : Print out all data members
+// 
+// Note        : 1. Print out "NOT SET" if the pointers are NULL.
+// 
+// Parameter   : None
+// ======================================================================================================
+   	int show() const {
+    	// TODO: Pretty Print, show the yt_attribute
+      
+      	return YT_SUCCESS;
+   	}
+
+
+//=======================================================================================================
+// Method      : validate
+// Description : Validate data member in the struct.
+// 
+// Note        : 1. Validate data member value in one yt_attribute struct.
+//                  (1) attr_name is set, and != NULL.
+//                  (2) attr_dtype is one of yt_ftype = {YT_FLOAT, YT_DOUBLE, YT_INT}.
+// 
+// Parameter   : None
+// ======================================================================================================
+   	int validate() const {
+   		// attr_name is set
+   		if ( attr_name == NULL ){
+   			YT_ABORT("attr_name is not set!\n");
+   		}
+
+   		// attr_dtype is one of yt_ftype = {YT_FLOAT, YT_DOUBLE, YT_INT}.
+   		if ( attr_dtype != YT_FLOAT && attr_dtype != YT_DOUBLE && attr_dtype != YT_INT ){
+   			YT_ABORT("attr_dtype is not set properly, unknown attr_dtype == %d!\n", attr_dtype);
+   		}
+
+      	return YT_SUCCESS;
+   	}
+
+
+//=======================================================================================================
+// Method      : ~yt_attribute
+// Description : Destructor of the structure "yt_attribute"
+// 
+// Note        : 1. Not used currently
+// 
+// Parameter   : None
+//=======================================================================================================
+   	~yt_attribute()
+   	{
+
+   	}
+};
+
+
+//-------------------------------------------------------------------------------------------------------
+// Structure   :  yt_particle
+// Description :  Data structure to store particle info and function to get them.
+// 
+// Notes       :  1. In YT, a particle type is "species_name" here.
+//                2. attr_list must only contain attributes that can get by get_attr.
+//
+// Data Member :  char         *species_name  : Species of this particle.
+//                int           num_attr      : Length of the attr_list.
+//                yt_attribute *attr_list     : Attribute list, contains a list of attributes name, and 
+//                                              function pointer get_attr knows how to get these data.
+//                char         *coor_x        : Attribute name of coordinate x.
+//                char         *coor_y        : Attribute name of coordinate y.
+//                char         *coor_z        : Attribute name of coordinate z.
+//                
+//                (func pointer) get_attr     : pointer to function with arguments (long, char*, void*) 
+//                                              that gets particle attribute.
+//
+// Method      :  yt_particle  : Constructor
+//               ~yt_particle  : Destructor
+//                show         : Print data member value
+//                validate     : Validate data member in struct
+//-------------------------------------------------------------------------------------------------------
+struct yt_particle
+{
+// data members
+// ======================================================================================================
+	char         *species_name;
+	int           num_attr;
+	yt_attribute *attr_list;
+
+	char         *coor_x;
+	char         *coor_y;
+	char         *coor_z;
+
+	void        (*get_attr) (long, char*, void*);
+
+
+//=======================================================================================================
+// Method      : yt_particle
+// Description : Constructor of the structure "yt_particle"
+// 
+// Note        : 1. 
+// 
+// Parameter   : None
+// ======================================================================================================
+	yt_particle()
+	{
+		species_name = NULL;
+		num_attr = INT_UNDEFINED;
+		attr_list = NULL;
+
+		coor_x = NULL;
+		coor_y = NULL;
+		coor_z = NULL;
+
+		get_attr = NULL;
+	}
+
+
+//=======================================================================================================
+// Method      : show
+// Description : Print out all data members
+// 
+// Note        : 1. Print out "NOT SET" if the pointers are NULL.
+// 
+// Parameter   : None
+// ======================================================================================================
+   	int show() const {
+    	// TODO: Pretty Print, show the yt_particle
+      
+      	return YT_SUCCESS;
+   	}
+
+
+//=======================================================================================================
+// Method      : validate
+// Description : Validate data member in the struct.
+// 
+// Note        : 1. Validate data member value in one yt_particle struct.
+//                  (1) species_name is set != NULL
+//                  (2) attr_list is set != NULL
+//                  (3) num_attr should > 0
+//                  (4) attr_name in attr_list should be unique 
+//                  (5) call yt_attribute validate for each attr_list elements.
+//                  (6) raise log_warning if coor_x, coor_y, coor_z is not set.
+//                  (7) raise log_warning if get_attr not set.
+// 
+// Parameter   : None
+// ======================================================================================================
+   	int validate() const {
+   		// species_name should be set
+   		if ( species_name == NULL ){
+   			YT_ABORT("species_name is not set!\n");
+   		}
+
+   		// attr_list != NULL
+   		if ( attr_list == NULL ){
+   			YT_ABORT("attr_list not set properly!\n");
+   		}
+		// num_attr should > 0
+   		if ( num_attr < 0 ){
+   			YT_ABORT("num_attr not set properly!\n");
+   		}
+   		
+   		// call yt_attribute validate for each attr_list elements.
+   		for ( int i = 0; i < num_attr; i++ ){
+   			if ( !(attr_list[i].validate()) ){
+   				YT_ABORT("attr_list element [ %d ] not set properly!\n", i);
+   			}
+   		}
+
+   		// attr_name in attr_list should be unique
+   		for ( int i = 0; i < num_attr; i++ ){
+   			for ( int j = i+1; j < num_attr; j++ ){
+   				if ( strcmp(attr_list[i].attr_name, attr_list[j].attr_name) == 0 ){
+   					YT_ABORT("attr_list element [ %d ] and [ %d ] have same attr_name, expect them to be unique!\n", i, j);
+   				}
+   			}
+   		}
+
+   		// if didn't input coor_x/y/z, yt cannot function properly for this particle.
+   		if ( coor_x == NULL ){
+   			log_warning("Attribute name of coordinate x coor_x not set!\n");
+   		}
+   		if ( coor_y == NULL ){
+   			log_warning("Attribute name of coordinate y coor_y not set!\n");
+   		}
+   		if ( coor_z == NULL ){
+   			log_warning("Attribute name of coordinate z coor_z not set!\n");
+   		}
+
+   		// if didn't input get_attr, yt cannot function properly for this particle.
+   		if ( get_attr == NULL ){
+   			log_warning("Function that gets particle attribute get_attr not set!\n");
+   		}
+
+      	return YT_SUCCESS;
+   	}
+
+
+//=======================================================================================================
+// Method      : ~yt_particle
+// Description : Destructor of the structure "yt_particle"
+// 
+// Note        : 1. Not used currently
+// 
+// Parameter   : None
+//=======================================================================================================
+	~yt_particle()
+	{
+
+	} // METHOD : ~yt_particle
+
+};
+
+#endif // #ifndef __YT_TYPE_PARTICLE_H__

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -82,7 +82,7 @@ struct yt_attribute
 	{
 		attr_name = NULL;
 		attr_dtype = YT_DOUBLE;
-		attr_unit = "NOT SET";
+		attr_unit = "";
 		num_attr_name_alias = 0;
 		attr_name_alias = NULL;
 		attr_display_name = NULL;

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -260,7 +260,8 @@ struct yt_particle
    		for ( int i = 0; i < num_attr; i++ ){
    			for ( int j = i+1; j < num_attr; j++ ){
    				if ( strcmp(attr_list[i].attr_name, attr_list[j].attr_name) == 0 ){
-   					YT_ABORT("attr_list element [ %d ] and [ %d ] have same attr_name, expect them to be unique!\n", i, j);
+   					YT_ABORT("In particle species [ %s ], attr_list element [ %d ] and [ %d ] have same attr_name, expect them to be unique!\n", 
+   						      species_name, i, j);
    				}
    			}
    		}

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -27,6 +27,12 @@ struct yt_species
 {
 	char *species_name;
 	int   num_attr;
+
+	yt_species()
+	{
+		species_name = NULL;
+		num_attr     = INT_UNDEFINED;
+	}
 };
 
 //-------------------------------------------------------------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,8 +11,8 @@
 # source files
 #######################################################################################################
 CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt_add_user_parameter.cpp \
-           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_get_fieldsPtr.cpp yt_free_gridsPtr.cpp            \
-           yt_getGridInfo.cpp
+           yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_get_fieldsPtr.cpp yt_get_particlesPtr.cpp         \
+           yt_free_gridsPtr.cpp yt_getGridInfo.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
 		   check_hierarchy.cpp append_grid.cpp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ LIB_SONAME   := libyt.so.1
 
 # different paths
 #######################################################################################################
-PYTHON_PATH := $(YOUR_PYTHON_PATH)
+PYTHON_PATH := /home/cindytsai/software/python/python3.8
 OBJ_PATH := ./obj
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ LIB_SONAME   := libyt.so.1
 
 # different paths
 #######################################################################################################
-PYTHON_PATH := /home/cindytsai/software/python/python3.8
+PYTHON_PATH := $(YOUR_PYTHON_PATH)
 OBJ_PATH := ./obj
 
 

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -341,7 +341,7 @@ int add_dict_particle_list(){
                       g_param_yt.particle_list[s].species_name, attr.attr_unit, "attr_unit");
          }
          Py_DECREF( val );
-         
+
          // Create name_alias_list and append to attr_list
          PyObject *name_alias_list = PyList_New(0);
          for ( int i = 0; i < attr.num_attr_name_alias; i++ ){

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -334,11 +334,11 @@ int add_dict_particle_list(){
          PyObject    *attr_list = PyList_New(0);
          yt_attribute attr      = g_param_yt.particle_list[s].attr_list[a];
 
-         // Append attr_name to attr_list
-         val = PyUnicode_FromString( attr.attr_name );
+         // Append attr_unit to attr_list
+         val = PyUnicode_FromString( attr.attr_unit );
          if ( PyList_Append(attr_list, val) != 0 ){
-            YT_ABORT("In species_name == %s, attr_name == %s, failed to append %s to list.\n",
-                      g_param_yt.particle_list[s].species_name, attr.attr_name, "attr_name");
+            YT_ABORT("In species_name == %s, attr_unit == %s, failed to append %s to list.\n",
+                      g_param_yt.particle_list[s].species_name, attr.attr_unit, "attr_unit");
          }
          Py_DECREF( val );
          

--- a/src/add_dict.cpp
+++ b/src/add_dict.cpp
@@ -395,26 +395,51 @@ int add_dict_particle_list(){
 
       // Create coor_list and insert it to species_dict with key = "particle_coor_label"
       PyObject *coor_list = PyList_New(0);
-      val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_x );
-      if ( PyList_Append(coor_list, val) != 0 ){
-         YT_ABORT("In species_name == %s, coor_x == %s, failed to append %s to list.\n",
-                   g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_x, "coor_x");
-      }
-      Py_DECREF( val );
 
-      val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_y );
-      if ( PyList_Append(coor_list, val) != 0 ){
-         YT_ABORT("In species_name == %s, coor_y == %s, failed to append %s to list.\n",
-                   g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_y, "coor_y");
+      if ( g_param_yt.particle_list[s].coor_x == NULL ){
+         if ( PyList_Append(coor_list, Py_None) != 0 ){
+            YT_ABORT("In species_name == %s, coor_x == NULL, failed to append %s to coor_list.\n",
+                      g_param_yt.particle_list[s].species_name, "Py_None");
+         }
       }
-      Py_DECREF( val );
+      else{
+         val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_x );
+         if ( PyList_Append(coor_list, val) != 0 ){
+            YT_ABORT("In species_name == %s, coor_x == %s, failed to append %s to list.\n",
+                      g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_x, "coor_x");
+         }
+         Py_DECREF( val );
+      }
 
-      val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_z );
-      if ( PyList_Append(coor_list, val) != 0 ){
-         YT_ABORT("In species_name == %s, coor_z == %s, failed to append %s to list.\n",
-                   g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_z, "coor_z");
+      if ( g_param_yt.particle_list[s].coor_y == NULL ){
+         if ( PyList_Append(coor_list, Py_None) != 0 ){
+            YT_ABORT("In species_name == %s, coor_y == NULL, failed to append %s to coor_list.\n",
+                      g_param_yt.particle_list[s].species_name, "Py_None");
+         }
       }
-      Py_DECREF( val );
+      else{
+         val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_y );
+         if ( PyList_Append(coor_list, val) != 0 ){
+            YT_ABORT("In species_name == %s, coor_y == %s, failed to append %s to list.\n",
+                      g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_y, "coor_y");
+         }
+         Py_DECREF( val );
+      }
+
+      if ( g_param_yt.particle_list[s].coor_z == NULL ){
+         if ( PyList_Append(coor_list, Py_None) != 0 ){
+            YT_ABORT("In species_name == %s, coor_z == NULL, failed to append %s to coor_list.\n",
+                      g_param_yt.particle_list[s].species_name, "Py_None");
+         }
+      }
+      else{
+         val = PyUnicode_FromString( g_param_yt.particle_list[s].coor_z );
+         if ( PyList_Append(coor_list, val) != 0 ){
+            YT_ABORT("In species_name == %s, coor_z == %s, failed to append %s to list.\n",
+                      g_param_yt.particle_list[s].species_name, g_param_yt.particle_list[s].coor_z, "coor_z");
+         }
+         Py_DECREF( val );
+      }
 
       // Insert coor_list to species_dict with key = "particle_coor_label"
       if ( PyDict_SetItemString(species_dict, "particle_coor_label", coor_list) != 0 ){

--- a/src/allocate_hierarchy.cpp
+++ b/src/allocate_hierarchy.cpp
@@ -5,7 +5,7 @@
 // Function    :  allocate_hierarchy
 // Description :  Fill the libyt.hierarchy dictionary with NumPy arrays allocated but uninitialized
 //
-// Note        :  1. Called by yt_set_parameter(), since it needs param_yt.num_grids, param_yt.num_fields in .
+// Note        :  1. Called by yt_set_parameter(), since it needs param_yt.num_grids.
 //                2. These NumPy array will be set when calling yt_commit_grids()
 //
 // Parameter   :  None

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -31,13 +31,13 @@ int append_grid( yt_grid *grid ){
       }                                                                                                  \
    }
 
-   FILL_ARRAY( "grid_left_edge",       grid->left_edge,      3, npy_double );
-   FILL_ARRAY( "grid_right_edge",      grid->right_edge,     3, npy_double );
-   FILL_ARRAY( "grid_dimensions",      grid->grid_dimensions,3, npy_long   );
-   FILL_ARRAY( "grid_particle_count", &grid->particle_count, 1, npy_long   );
-   FILL_ARRAY( "grid_parent_id",      &grid->parent_id,      1, npy_long   );
-   FILL_ARRAY( "grid_levels",         &grid->level,          1, npy_long   );
-   FILL_ARRAY( "proc_num",            &grid->proc_num,       1, npy_int    );
+   FILL_ARRAY( "grid_left_edge",       grid->left_edge,           3, npy_double );
+   FILL_ARRAY( "grid_right_edge",      grid->right_edge,          3, npy_double );
+   FILL_ARRAY( "grid_dimensions",      grid->grid_dimensions,     3, npy_long   );
+   FILL_ARRAY( "grid_particle_count", &grid->grid_particle_count, 1, npy_long   );
+   FILL_ARRAY( "grid_parent_id",      &grid->parent_id,           1, npy_long   );
+   FILL_ARRAY( "grid_levels",         &grid->level,               1, npy_long   );
+   FILL_ARRAY( "proc_num",            &grid->proc_num,            1, npy_int    );
    log_debug( "Inserting grid [%15ld] info to libyt.hierarchy ... done\n", grid->id );
 
 // export grid data to libyt.grid_data as "libyt.grid_data[grid_id][field_list.field_name][field_data.data_ptr]"

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -11,6 +11,7 @@
 // Lists       :       Python Method         C Extension Function         
 //              .............................................................
 //                     derived_func          libyt_field_derived_func
+//                     get_attr              libyt_particle_get_attr
 //-------------------------------------------------------------------------------------------------------
 
 //-------------------------------------------------------------------------------------------------------
@@ -28,7 +29,7 @@
 // Parameter   :  int : GID of the grid
 //                str : field name
 //
-// Return      :  numpy.ndarray
+// Return      :  numpy.3darray
 //-------------------------------------------------------------------------------------------------------
 static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
 
@@ -129,6 +130,149 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
     return derived_NpArray;
 }
 
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  libyt_particle_get_attr
+// Description :  Use the get_attr defined inside yt_particle struct to get the particle attributes.
+//
+// Note        :  1. Support only grid dimension = 3 for now, which is "coor_x", "coor_y", "coor_z" in
+//                   yt_particle must be set.
+//                2. We assume that parallelism in yt will make each rank only has to deal with the local
+//                   grids. So we can always find one grid with id = gid inside grids_local. We will only
+//                   get particle that belongs to this id.
+//                   (Maybe we can add feature get grids data from other rank in the future!)
+//                3. The returned numpy array data type well be set by attr_dtype.
+//                4. We will always return 1D numpy array, with length equal particle count of that grid.
+//                   Since we will only call this function if particle_count > 0.
+//                
+// Parameter   :  int : GID of the grid
+//                str : ptype, particle species, ex:"io"
+//                str : attribute, or in terms in yt, which is particle.
+//
+// Return      :  numpy.1darray
+//-------------------------------------------------------------------------------------------------------
+static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
+    // Parse the input arguments input by python.
+    // If not in the format libyt.get_attr( int , str , str ), raise an error
+    long  gid;
+    char *ptype;
+    char *attr_name;
+
+    if ( !PyArg_ParseTuple(args, "lss", &gid, &ptype, &attr_name) ){
+        PyErr_SetString(PyExc_TypeError, "Wrong input type, expect to be libyt.get_attr(int, str, str).");
+        return NULL;
+    }
+
+    
+    // Get get_attr function pointer defined in particle_list according to ptype and attr_name.
+    // Get attr_dtype of the attr_name.
+    // If cannot find ptype or attr_name, raise an error.
+    // If find them successfully, but get_attr not set, which is == NULL, raise an error.
+    void    (*get_attr) (long, char*, void*);
+    yt_ftype attr_dtype;
+    bool     have_ptype = false;
+    bool     have_attr_name = false;
+
+    for ( int s = 0; s < g_param_yt.num_species; s++ ){
+        if ( strcmp(g_param_yt.particle_list[s].species_name, ptype) == 0 ){
+            have_ptype = true;
+
+            // Get get_attr
+            if ( g_param_yt.particle_list[s].get_attr != NULL ){
+                get_attr = g_param_yt.particle_list[s].get_attr;
+            }
+            else {
+                PyErr_Format(PyExc_NotImplementedError, "In particle_list, species_name [ %s ], get_attr does not set properly.\n",
+                             g_param_yt.particle_list[s].species_name);
+                return NULL;
+            }
+
+            // Get attr_dtype
+            for ( int p = 0; p < g_param_yt.particle_list[s].num_attr; p++ ){
+                if ( strcmp(g_param_yt.particle_list[s].attr_list[p].attr_name, attr_name) == 0 ){
+                    have_attr_name = true;
+                    // Since in yt_attribute validate(), we have already make sure that attr_dtype is set.
+                    // So we don't need additional check
+                    attr_dtype = g_param_yt.particle_list[s].attr_list[p].attr_dtype;
+                    break;
+                }
+            }
+
+            break;
+        }
+    }
+
+    if ( !have_ptype ){
+        PyErr_Format(PyExc_ValueError, "Cannot find species_name [ %s ] in particle_list.\n", ptype);
+        return NULL;
+    }
+    if ( !have_attr_name ){
+        PyErr_Format(PyExc_ValueError, "species_name [ %s ], attr_name [ %s ] not in particle_list.\n",
+                     ptype, attr_name);
+        return NULL;
+    }
+
+
+    // Get lenght of the returned 1D numpy array, which is equal to particle_count in the grid.
+    long  array_length;
+    bool  have_Grid = false;
+
+    for (int lid = 0; lid < g_param_yt.num_grids_local; lid++){
+        if ( g_param_yt.grids_local[lid].id == gid ){
+            have_Grid = true;
+            array_length = g_param_yt.grids_local[lid].particle_count;
+            break;
+        }
+    }
+
+    if ( !have_Grid ){
+        int MyRank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+        PyErr_Format(PyExc_ValueError, "Cannot find grid with GID [ %ld ] on MPI rank [%d].\n", gid, MyRank);
+        return NULL;
+    }
+
+
+    // Allocate the output array with size = array_length, type = attr_dtype, and initialize as 0
+    // Then pass in to get_attr(long, char*, void*) function
+    // Finally, return numpy 1D array, by wrapping the output.
+    // We do not need to free output, since we make python owns this data after returning.
+    int      nd = 1;
+    int      typenum;
+    npy_intp dims[1] = { array_length };
+    void     *output;
+
+    if ( attr_dtype == YT_INT ){
+        typenum = NPY_INT;
+        output = malloc( array_length * sizeof(int) );
+        for ( int i = 0; i < array_length; i++ ){ 
+            ((int *)output)[i] = 0;
+        }
+        get_attr(gid, attr_name, output);
+    }
+    else if ( attr_dtype == YT_FLOAT ){
+        typenum = NPY_FLOAT;
+        output = malloc( array_length * sizeof(float) );
+        for ( int i = 0; i < array_length; i++ ){ 
+            ((float *)output)[i] = 0;
+        }
+        get_attr(gid, attr_name, output);
+    }
+    else if ( attr_dtype == YT_DOUBLE ){
+        typenum = NPY_DOUBLE;
+        output = malloc( array_length * sizeof(double) );
+        for ( int i = 0; i < array_length; i++ ){ 
+            ((double *)output)[i] = 0;
+        }
+        get_attr(gid, attr_name, output);
+    }
+
+    PyObject *outputNumpyArray = PyArray_SimpleNewFromData(nd, dims, typenum, output);
+    PyArray_ENABLEFLAGS( (PyArrayObject*) outputNumpyArray, NPY_ARRAY_OWNDATA);
+
+    return outputNumpyArray;
+}
+
 //-------------------------------------------------------------------------------------------------------
 // Description :  Preparation for creating libyt python module
 //
@@ -147,6 +291,8 @@ static PyMethodDef libyt_method_list[] =
 // { "method_name", c_function_name, METH_VARARGS, "Description"},
    {"derived_func", libyt_field_derived_func, METH_VARARGS, 
     "Input GID and field name, and get the field data derived by derived_func."},
+   {"get_attr",     libyt_particle_get_attr,  METH_VARARGS,
+    "Input GID, ptype, particle (which is attribute), and get the particle attribute by get_attr."},
    { NULL, NULL, 0, NULL } // sentinel
 };
 

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -142,8 +142,8 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
 //                   get particle that belongs to this id.
 //                   (Maybe we can add feature get grids data from other rank in the future!)
 //                3. The returned numpy array data type well be set by attr_dtype.
-//                4. We will always return 1D numpy array, with length equal particle count of that grid.
-//                   Since we will only call this function if particle_count > 0.
+//                4. We will always return 1D numpy array, with length equal particle count of the species 
+//                   in that grid.
 //                
 // Parameter   :  int : GID of the grid
 //                str : ptype, particle species, ex:"io"
@@ -172,10 +172,12 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     yt_ftype attr_dtype;
     bool     have_ptype = false;
     bool     have_attr_name = false;
+    int      species_index;
 
     for ( int s = 0; s < g_param_yt.num_species; s++ ){
         if ( strcmp(g_param_yt.particle_list[s].species_name, ptype) == 0 ){
             have_ptype = true;
+            species_index = s;
 
             // Get get_attr
             if ( g_param_yt.particle_list[s].get_attr != NULL ){
@@ -213,14 +215,14 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     }
 
 
-    // Get lenght of the returned 1D numpy array, which is equal to particle_count in the grid.
+    // Get lenght of the returned 1D numpy array, which is equal to particle_count_list in the grid.
     long  array_length;
     bool  have_Grid = false;
 
     for (int lid = 0; lid < g_param_yt.num_grids_local; lid++){
         if ( g_param_yt.grids_local[lid].id == gid ){
             have_Grid = true;
-            array_length = g_param_yt.grids_local[lid].particle_count;
+            array_length = g_param_yt.grids_local[lid].particle_count_list[species_index];
             break;
         }
     }

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -245,7 +245,7 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     if ( attr_dtype == YT_INT ){
         typenum = NPY_INT;
         output = malloc( array_length * sizeof(int) );
-        for ( int i = 0; i < array_length; i++ ){ 
+        for ( long i = 0; i < array_length; i++ ){ 
             ((int *)output)[i] = 0;
         }
         get_attr(gid, attr_name, output);
@@ -253,7 +253,7 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     else if ( attr_dtype == YT_FLOAT ){
         typenum = NPY_FLOAT;
         output = malloc( array_length * sizeof(float) );
-        for ( int i = 0; i < array_length; i++ ){ 
+        for ( long i = 0; i < array_length; i++ ){ 
             ((float *)output)[i] = 0;
         }
         get_attr(gid, attr_name, output);
@@ -261,7 +261,7 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     else if ( attr_dtype == YT_DOUBLE ){
         typenum = NPY_DOUBLE;
         output = malloc( array_length * sizeof(double) );
-        for ( int i = 0; i < array_length; i++ ){ 
+        for ( long i = 0; i < array_length; i++ ){ 
             ((double *)output)[i] = 0;
         }
         get_attr(gid, attr_name, output);

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -144,6 +144,7 @@ static PyObject* libyt_field_derived_func(PyObject *self, PyObject *args){
 //                3. The returned numpy array data type well be set by attr_dtype.
 //                4. We will always return 1D numpy array, with length equal particle count of the species 
 //                   in that grid.
+//                5. Return Py_None if number of ptype particle == 0.
 //                
 // Parameter   :  int : GID of the grid
 //                str : ptype, particle species, ex:"io"
@@ -223,6 +224,12 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
         if ( g_param_yt.grids_local[lid].id == gid ){
             have_Grid = true;
             array_length = g_param_yt.grids_local[lid].particle_count_list[species_index];
+            
+            if ( array_length == 0 ){
+                Py_INCREF(Py_None);
+                return Py_None;
+            }
+            
             break;
         }
     }

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -101,11 +101,11 @@ int yt_commit_grids()
          YT_ABORT(  "Validating input grid ID [%ld] ... failed\n", grid.id );
 
       // check particle_count_list element > 0 if this array is set.
-      // and sum it up
-      grid.grid_particle_count = 0;
+      // and sum it up. Be careful the copy of struct, we wish to write changes in g_param_yt.grids_local
+      g_param_yt.grids_local[i].grid_particle_count = 0;
       for ( int s = 0; s < g_param_yt.num_species; s++ ){
          if ( grid.particle_count_list[s] >= 0 ){
-            grid.grid_particle_count = grid.grid_particle_count + grid.particle_count_list[s];
+            g_param_yt.grids_local[i].grid_particle_count += grid.particle_count_list[s];
          }
          else{
             YT_ABORT("Grid ID [%ld], particle count == %ld < 0, in particle species [%s]!\n",

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -9,7 +9,7 @@
 // Description :  Refresh the python yt state after finish inline-analysis
 //
 // Note        :  1. Call and use by user, after they are done with all the inline-analysis in this 
-//                   round.
+//                   round or they want to freed everything allocated by libyt.
 //
 // Parameter   :  None
 //
@@ -23,57 +23,57 @@ int yt_free_gridsPtr()
       YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
    }
 
-// check if YT parameters have been set
-   if ( !g_param_libyt.param_yt_set ){
-      YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
-   }
-
 // check if user has call yt_get_fieldsPtr()
-   if ( !g_param_libyt.get_fieldsPtr ){
-      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
-   if ( !g_param_libyt.get_gridsPtr ){
-      YT_ABORT( "Please invoke yt_get_gridsPtr() before calling %s()!\n", __FUNCTION__ );
-   }
-
-// check if user has call yt_commit_grids(), so that grids are appended to YT.
-   if ( !g_param_libyt.commit_grids ){
-      YT_ABORT( "Please invoke yt_commit_grids() before calling %s()!\n", __FUNCTION__ );
+   if ( !g_param_libyt.param_yt_set || !g_param_libyt.get_fieldsPtr || 
+        !g_param_libyt.get_particlesPtr || !g_param_libyt.get_gridsPtr || !g_param_libyt.commit_grids ){
+      log_warning( "You are going to free every libyt initialized and allocated array, 
+                    even though the inline-analysis procedure hasn't finished yet!\n" );
    }
 
    // Make sure every rank has reach to this point
    MPI_Barrier( MPI_COMM_WORLD );
 
-   // free resources to prepare for the next round
-   g_param_libyt.param_yt_set  = false;
-   g_param_libyt.get_fieldsPtr = false;
-   g_param_libyt.get_gridsPtr  = false;
-   g_param_libyt.commit_grids  = false;
+
+   // Free resource allocated in yt_set_parameter():
+   //    field_list, particle_list, attr_list, num_grids_local_MPI
+   if ( g_param_libyt.param_yt_set ){
+      
+      if ( g_param_yt.num_fields > 0 ){
+         delete [] g_param_yt.field_list;
+      }
+
+      if ( g_param_yt.num_species > 0 ){
+         for ( int i = 0; i < g_param_yt.num_species; i++ ){
+            delete [] g_param_yt.particle_list[i].attr_list;
+         }
+         delete [] g_param_yt.particle_list;
+      }
+
+      delete [] g_param_yt.num_grids_local_MPI;
+   }
+
+   // Free resource allocated in yt_get_gridsPtr():
+   //    grids_local, field_data, particle_count_list
+   if ( g_param_libyt.get_gridsPtr ){
+      for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
+         if ( g_param_yt.num_fields > 0 ){
+            delete [] g_param_yt.grids_local[i].field_data;
+         }
+         if ( g_param_yt.num_species > 0 ){
+            delete [] g_param_yt.grids_local[i].particle_count_list;
+         }
+      }
+      delete [] g_param_yt.grids_local;
+   }
+
+
+   // Reset check points
+   g_param_libyt.param_yt_set     = false;
+   g_param_libyt.get_fieldsPtr    = false;
+   g_param_libyt.get_particlesPtr = false;
+   g_param_libyt.get_gridsPtr     = false;
+   g_param_libyt.commit_grids     = false;
    g_param_libyt.counter ++;
-
-   // Free grids_local, num_grids_local_MPI, field_list
-   for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
-      if ( g_param_yt.grids_local[i].field_data != NULL ){
-         delete [] g_param_yt.grids_local[i].field_data;
-      }
-      if ( g_param_yt.grids_local[i].particle_count_list != NULL ){
-         delete [] g_param_yt.grids_local[i].particle_count_list;
-      }
-   }
-   delete [] g_param_yt.grids_local;
-   delete [] g_param_yt.num_grids_local_MPI;
-
-   if ( g_param_yt.field_list != NULL ){
-      delete [] g_param_yt.field_list;
-   }
-   if ( g_param_yt.particle_list != NULL ){
-      for ( int i = 0; i < g_param_yt.num_species; i++ ){
-         delete [] g_param_yt.particle_list[i].attr_list;
-      }
-      delete [] g_param_yt.particle_list;
-   }
 
    // Reset g_param_yt
    g_param_yt.init();

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -26,8 +26,7 @@ int yt_free_gridsPtr()
 // check if user has call yt_get_fieldsPtr()
    if ( !g_param_libyt.param_yt_set || !g_param_libyt.get_fieldsPtr || 
          !g_param_libyt.get_particlesPtr || !g_param_libyt.get_gridsPtr || !g_param_libyt.commit_grids ){
-         log_warning( "You are going to free every libyt initialized and allocated array, \
-                       even though the inline-analysis procedure has not finished yet!\n" );
+         log_warning( "You are going to free every libyt initialized and allocated array, even though the inline-analysis procedure has not finished yet!\n" );
    }
 
    // Make sure every rank has reach to this point

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -55,7 +55,12 @@ int yt_free_gridsPtr()
 
    // Free grids_local, num_grids_local_MPI, field_list
    for (int i = 0; i < g_param_yt.num_grids_local; i = i+1){
-      delete [] g_param_yt.grids_local[i].field_data;
+      if ( g_param_yt.grids_local[i].field_data != NULL ){
+         delete [] g_param_yt.grids_local[i].field_data;
+      }
+      if ( g_param_yt.grids_local[i].particle_count_list != NULL ){
+         delete [] g_param_yt.grids_local[i].particle_count_list;
+      }
    }
    delete [] g_param_yt.grids_local;
    delete [] g_param_yt.num_grids_local_MPI;

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -25,9 +25,9 @@ int yt_free_gridsPtr()
 
 // check if user has call yt_get_fieldsPtr()
    if ( !g_param_libyt.param_yt_set || !g_param_libyt.get_fieldsPtr || 
-        !g_param_libyt.get_particlesPtr || !g_param_libyt.get_gridsPtr || !g_param_libyt.commit_grids ){
-      log_warning( "You are going to free every libyt initialized and allocated array, 
-                    even though the inline-analysis procedure hasn't finished yet!\n" );
+         !g_param_libyt.get_particlesPtr || !g_param_libyt.get_gridsPtr || !g_param_libyt.commit_grids ){
+         log_warning( "You are going to free every libyt initialized and allocated array, \
+                       even though the inline-analysis procedure has not finished yet!\n" );
    }
 
    // Make sure every rank has reach to this point

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -59,7 +59,16 @@ int yt_free_gridsPtr()
    }
    delete [] g_param_yt.grids_local;
    delete [] g_param_yt.num_grids_local_MPI;
-   delete [] g_param_yt.field_list;
+
+   if ( g_param_yt.field_list != NULL ){
+      delete [] g_param_yt.field_list;
+   }
+   if ( g_param_yt.particle_list != NULL ){
+      for ( int i = 0; i < g_param_yt.num_species; i++ ){
+         delete [] g_param_yt.particle_list[i].attr_list;
+      }
+      delete [] g_param_yt.particle_list;
+   }
 
    // Reset g_param_yt
    g_param_yt.init();

--- a/src/yt_free_gridsPtr.cpp
+++ b/src/yt_free_gridsPtr.cpp
@@ -65,15 +65,6 @@ int yt_free_gridsPtr()
       delete [] g_param_yt.grids_local;
    }
 
-
-   // Reset check points
-   g_param_libyt.param_yt_set     = false;
-   g_param_libyt.get_fieldsPtr    = false;
-   g_param_libyt.get_particlesPtr = false;
-   g_param_libyt.get_gridsPtr     = false;
-   g_param_libyt.commit_grids     = false;
-   g_param_libyt.counter ++;
-
    // Reset g_param_yt
    g_param_yt.init();
    
@@ -83,6 +74,14 @@ int yt_free_gridsPtr()
    PyDict_Clear( g_py_param_user );
 
    PyRun_SimpleString( "gc.collect()" );
+   
+   // Reset check points
+   g_param_libyt.param_yt_set     = false;
+   g_param_libyt.get_fieldsPtr    = false;
+   g_param_libyt.get_particlesPtr = false;
+   g_param_libyt.get_gridsPtr     = false;
+   g_param_libyt.commit_grids     = false;
+   g_param_libyt.counter ++;   
 
    g_param_libyt.free_gridsPtr = true;
 

--- a/src/yt_getGridInfo.cpp
+++ b/src/yt_getGridInfo.cpp
@@ -23,9 +23,16 @@ int check_procedure( const char *callFunc ){
     	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_set_parameter() before calling %s()!\n", callFunc );
    	}
 
-	// check if user has call yt_get_fieldsPtr()
+	// check if user sets field_list
    	if ( !g_param_libyt.get_fieldsPtr ){
-    	YT_ABORT( "Please follow the libyt procedure, forgot to invode yt_get_fieldsPtr() before calling %s()!\n", callFunc );
+      	YT_ABORT( "num_fields == %d, please invoke yt_get_fieldsPtr() before calling %s()!\n",
+                   g_param_yt.num_fields, callFunc );
+   	}
+
+	// check if user sets particle_list
+   	if ( !g_param_libyt.get_particlesPtr ){
+      	YT_ABORT( "num_species == %d, please invoke yt_get_particlesPtr() before calling %s()!\n",
+                   g_param_yt.num_species, callFunc );
    	}
 
 	// check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
@@ -33,7 +40,7 @@ int check_procedure( const char *callFunc ){
       	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_get_gridsPtr() before calling %s()!\n", callFunc );
    	}
 
-	// check if user has call yt_commit_grids(), so that grids are appended to YT.
+	// check if user has call yt_commit_grids(), so that grids are checked and appended to YT.
    	if ( !g_param_libyt.commit_grids ){
       	YT_ABORT( "Please follow the libyt procedure, forgot to invoke yt_commit_grids() before calling %s()!\n", callFunc );
    	}

--- a/src/yt_get_fieldsPtr.cpp
+++ b/src/yt_get_fieldsPtr.cpp
@@ -5,7 +5,8 @@
 // Function    :  yt_get_fieldsPtr
 // Description :  Get pointer of the array of struct yt_field with length num_fields.
 //
-// Note        :  1. User should call this function after yt_set_parameter(), since we need num_fields.
+// Note        :  1. User should call this function after yt_set_parameter(), since we allocate field_list
+//                   there.
 //
 // Parameter   :  yt_field **field_list  : Initialize and store the field list array under this pointer 
 //                                         points to.
@@ -25,13 +26,16 @@ int yt_get_fieldsPtr( yt_field **field_list )
     	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
     }
 
+    // check if num_fields > 0, if not, particle_list won't be initialized
+    if ( g_param_yt.num_fields <= 0 ){
+    	YT_ABORT( "num_fields == %d <= 0, you don't need to input field_list, and it is also not initialized!\n",
+    	           g_param_yt.num_fields);
+    }
+
    	log_info( "Getting pointer to field list information ...\n" );
 
-	// Initialize the field_list array.
-	*field_list = new yt_field [g_param_yt.num_fields];
-
-	// Store the field_list to g_param_yt
-	g_param_yt.field_list = *field_list;
+	// Store the field_list ptr to *field_list
+	*field_list =  g_param_yt.field_list;
 
 	// Above all works like charm
 	g_param_libyt.get_fieldsPtr = true;

--- a/src/yt_get_fieldsPtr.cpp
+++ b/src/yt_get_fieldsPtr.cpp
@@ -26,7 +26,7 @@ int yt_get_fieldsPtr( yt_field **field_list )
     	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
     }
 
-    // check if num_fields > 0, if not, particle_list won't be initialized
+    // check if num_fields > 0, if not, field_list won't be initialized
     if ( g_param_yt.num_fields <= 0 ){
     	YT_ABORT( "num_fields == %d <= 0, you don't need to input field_list, and it is also not initialized!\n",
     	           g_param_yt.num_fields);

--- a/src/yt_get_fieldsPtr.cpp
+++ b/src/yt_get_fieldsPtr.cpp
@@ -17,7 +17,7 @@ int yt_get_fieldsPtr( yt_field **field_list )
 {
 	// check if libyt has been initialized
    	if ( !g_param_libyt.libyt_initialized ){
-    	YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );     	
+    	YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );
    	}
 
 	// check if yt_set_parameter() have been called

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -5,11 +5,13 @@
 // Function    :  yt_get_gridsPtr
 // Description :  Get pointer of the array of struct yt_grid with length num_grids_local.
 //
-// Note        :  1. User should call this function after yt_set_parameter() and yt_get_fieldsPtr, 
-//                   since we need num_grids_local, and field info.
+// Note        :  1. User should call this function after yt_set_parameter(), 
+//                   since we need num_grids_local, num_fields, and num_species.
 //                2. Initialize field_data in one grid with
 //                   (1) data_dim[3] = {0, 0, 0}
 //                   (2) data_ptr    = NULL
+//                3. If user call this function twice, then it will just return the previously initialized 
+//                   and allocated array.
 //
 // Parameter   :  yt_grid **grids_local : Initialize and store the grid structure array under this 
 //                                        pointer points to.
@@ -29,53 +31,57 @@ int yt_get_gridsPtr( yt_grid **grids_local )
     	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
     }
 
-    // check if yt_get_fieldsPtr() have been called
-    if ( !g_param_libyt.get_fieldsPtr ) {
-    	YT_ABORT( "Please invoke yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
-    }
-
    	log_info( "Getting pointer to local grids information ...\n" );
 
-   	// Get the MPI rank
-   	int MyRank;
-   	MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
+   	// If user call for the first time.
+   	if ( !g_param_libyt.get_gridsPtr ){
+	   	// Get the MPI rank
+	   	int MyRank;
+	   	MPI_Comm_rank(MPI_COMM_WORLD, &MyRank);
 
-	// Initialize the grids_local array.
-	// Set the value if overlapped with g_param_yt,
-	// and each fields data are set to NULL, so that we can check if user input the data
-	*grids_local = new yt_grid [g_param_yt.num_grids_local];
-	for ( int id = 0; id < g_param_yt.num_grids_local; id = id+1 ){
-		
-		(*grids_local)[id].proc_num     = MyRank;
-		
-		// Dealing with individual field in one grid
-		if ( g_param_yt.num_fields > 0 ){
-			(*grids_local)[id].field_data   = new yt_data [g_param_yt.num_fields];
-			for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1 ){
-				for ( int d = 0; d < 3; d++ ){
-					(*grids_local)[id].field_data[fid].data_dim[d] = 0;
+		// Initialize the grids_local array.
+		// Set the value if overlapped with g_param_yt,
+		// and each fields data are set to NULL, so that we can check if user input the data
+		*grids_local = new yt_grid [g_param_yt.num_grids_local];
+		for ( int id = 0; id < g_param_yt.num_grids_local; id = id+1 ){
+			
+			(*grids_local)[id].proc_num     = MyRank;
+			
+			// Dealing with individual field in one grid
+			if ( g_param_yt.num_fields > 0 ){
+				(*grids_local)[id].field_data   = new yt_data [g_param_yt.num_fields];
+				for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1 ){
+					for ( int d = 0; d < 3; d++ ){
+						(*grids_local)[id].field_data[fid].data_dim[d] = 0;
+					}
+					(*grids_local)[id].field_data[fid].data_ptr = NULL;
 				}
-				(*grids_local)[id].field_data[fid].data_ptr = NULL;
+			}
+			else{
+				(*grids_local)[id].field_data   = NULL;
+			}
+
+			// Dealing with particle_count
+			if ( g_param_yt.num_species > 0 ){
+				(*grids_local)[id].particle_count_list = new long [g_param_yt.num_species];
+				for ( int s = 0; s < g_param_yt.num_species; s++ ){
+					(*grids_local)[id].particle_count_list[s] = 0;
+				}
+			}
+			else{
+				(*grids_local)[id].particle_count_list = NULL;
 			}
 		}
-		else{
-			(*grids_local)[id].field_data   = NULL;
-		}
 
-		// Dealing with particle_count
-		if ( g_param_yt.num_species > 0 ){
-			(*grids_local)[id].particle_count_list = new long [g_param_yt.num_species];
-			for ( int s = 0; s < g_param_yt.num_species; s++ ){
-				(*grids_local)[id].particle_count_list[s] = 0;
-			}
-		}
-		else{
-			(*grids_local)[id].particle_count_list = NULL;
-		}
-	}
+		// Store the grids_local to g_param_yt
+		g_param_yt.grids_local = *grids_local;   		
+   	}
+   	else{
+   		// If user already called this function before, we just return the initialized grids_local,
+   		// to avoid memory leak.
+   		*grids_local = g_param_yt.grids_local;
+   	}
 
-	// Store the grids_local to g_param_yt
-	g_param_yt.grids_local = *grids_local;
 
 	// Above all works like charm
 	g_param_libyt.get_gridsPtr = true;

--- a/src/yt_get_gridsPtr.cpp
+++ b/src/yt_get_gridsPtr.cpp
@@ -47,14 +47,30 @@ int yt_get_gridsPtr( yt_grid **grids_local )
 	for ( int id = 0; id < g_param_yt.num_grids_local; id = id+1 ){
 		
 		(*grids_local)[id].proc_num     = MyRank;
-		(*grids_local)[id].field_data   = new yt_data [g_param_yt.num_fields];
 		
 		// Dealing with individual field in one grid
-		for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1 ){
-			for ( int d = 0; d < 3; d++ ){
-				(*grids_local)[id].field_data[fid].data_dim[d] = 0;
+		if ( g_param_yt.num_fields > 0 ){
+			(*grids_local)[id].field_data   = new yt_data [g_param_yt.num_fields];
+			for ( int fid = 0; fid < g_param_yt.num_fields; fid = fid+1 ){
+				for ( int d = 0; d < 3; d++ ){
+					(*grids_local)[id].field_data[fid].data_dim[d] = 0;
+				}
+				(*grids_local)[id].field_data[fid].data_ptr = NULL;
 			}
-			(*grids_local)[id].field_data[fid].data_ptr = NULL;
+		}
+		else{
+			(*grids_local)[id].field_data   = NULL;
+		}
+
+		// Dealing with particle_count
+		if ( g_param_yt.num_species > 0 ){
+			(*grids_local)[id].particle_count_list = new long [g_param_yt.num_species];
+			for ( int s = 0; s < g_param_yt.num_species; s++ ){
+				(*grids_local)[id].particle_count_list[s] = 0;
+			}
+		}
+		else{
+			(*grids_local)[id].particle_count_list = NULL;
 		}
 	}
 

--- a/src/yt_get_particlesPtr.cpp
+++ b/src/yt_get_particlesPtr.cpp
@@ -1,0 +1,35 @@
+#include "yt_combo.h"
+#include "libyt.h"
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  yt_get_particlesPtr
+// Description :  Get pointer of the array of struct yt_particle with length num_particles.
+//
+// Note        :  1. User should call this function after yt_set_parameter(), since we initialize 
+//                   particle_list then.
+//
+// Parameter   :  yt_particle **particle_list  : Store the particle list array pointer.
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+//
+int yt_get_particlesPtr( yt_particle **particle_list )
+{
+	// check if libyt has been initialized
+   	if ( !g_param_libyt.libyt_initialized ){
+    	YT_ABORT( "Please invoke yt_init() before calling %s()!\n", __FUNCTION__ );     	
+   	}
+
+	// check if yt_set_parameter() have been called
+   	if ( !g_param_libyt.param_yt_set ) {
+    	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
+    }
+
+   	log_info( "Getting pointer to particle list information ...\n" );
+
+   	*particle_list = g_param_yt.particle_list;
+
+	log_info( "Getting pointer to particle list information  ... done.\n" );
+	
+	return YT_SUCCESS;
+}

--- a/src/yt_get_particlesPtr.cpp
+++ b/src/yt_get_particlesPtr.cpp
@@ -25,10 +25,17 @@ int yt_get_particlesPtr( yt_particle **particle_list )
     	YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
     }
 
+    // check if num_species > 0, if not, particle_list won't be initialized
+    if ( g_param_yt.num_species <= 0 ){
+    	YT_ABORT( "num_species == %d <= 0, you don't need to input particle_list, and it is also not initialized!\n",
+    	           g_param_yt.num_species);
+    }
+
    	log_info( "Getting pointer to particle list information ...\n" );
 
    	*particle_list = g_param_yt.particle_list;
 
+   	g_param_libyt.get_particlesPtr = true;
 	log_info( "Getting pointer to particle list information  ... done.\n" );
 	
 	return YT_SUCCESS;

--- a/src/yt_inline.cpp
+++ b/src/yt_inline.cpp
@@ -28,9 +28,16 @@ int yt_inline_argument( char *function_name, int argc, ... ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
    }
 
-// check if user has call yt_get_fieldsPtr()
+// check if user sets field_list
    if ( !g_param_libyt.get_fieldsPtr ){
-      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
+      YT_ABORT( "num_fields == %d, please invoke yt_get_fieldsPtr() before calling %s()!\n",
+                 g_param_yt.num_fields, __FUNCTION__ );
+   }
+
+// check if user sets particle_list
+   if ( !g_param_libyt.get_particlesPtr ){
+      YT_ABORT( "num_species == %d, please invoke yt_get_particlesPtr() before calling %s()!\n",
+                 g_param_yt.num_species, __FUNCTION__ );
    }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.
@@ -115,9 +122,16 @@ int yt_inline( char *function_name ){
       YT_ABORT( "Please invoke yt_set_parameter() before calling %s()!\n", __FUNCTION__ );
    }
 
-// check if user has call yt_get_fieldsPtr()
+// check if user sets field_list
    if ( !g_param_libyt.get_fieldsPtr ){
-      YT_ABORT( "Please invode yt_get_fieldsPtr() before calling %s()!\n", __FUNCTION__ );
+      YT_ABORT( "num_fields == %d, please invoke yt_get_fieldsPtr() before calling %s()!\n",
+                 g_param_yt.num_fields, __FUNCTION__ );
+   }
+
+// check if user sets particle_list
+   if ( !g_param_libyt.get_particlesPtr ){
+      YT_ABORT( "num_species == %d, please invoke yt_get_particlesPtr() before calling %s()!\n",
+                 g_param_yt.num_species, __FUNCTION__ );
    }
 
 // check if user has call yt_get_gridsPtr(), so that libyt knows the local grids array ptr.

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -9,10 +9,13 @@
 // Description :  Set YT-specific parameters
 //
 // Note        :  1. Store yt relavent data in input "param_yt" to libyt.param_yt, not all the data are
-//                   passed in.
+//                   passed in to python. 
+//                   To avoid user free the passing in array species_list, we initialize particle_list 
+//                   (needs info from species_list) right away. If num_species > 0.
 //                2. Should be called after yt_init().
 //                3. Check the validaty of the data in param_yt.
-//                4. Organize and generate other information, for later runtime usage.
+//                4. Initialize python hierarchy allocate_hierarchy() and particle_list.
+//                5. Gather each ranks number of local grids, we need this info in yt_commit_grid().
 //
 // Parameter   :  param_yt : Structure storing YT-specific parameters that will later pass to YT, and
 //                           other relavent data.
@@ -115,6 +118,24 @@ int yt_set_parameter( yt_param_yt *param_yt )
       log_debug( "Allocating libyt.hierarchy ... done\n" );
    else
       YT_ABORT(  "Allocating libyt.hierarchy ... failed!\n" );
+
+
+// if num_species > 0, which means want to load particle
+   if ( g_param_yt.num_species > 0 ){
+      // Initialize and setup yt_particle *particle_list in g_param_yt.particle_list,
+      // to avoid user freeing yt_species *species_list.
+      yt_particle *particle_list = new yt_particle [ g_param_yt.num_species ];
+      for ( int s = 0; s < g_param_yt.num_species; s++ ){
+         particle_list[s].species_name = g_param_yt.species_list[s].species_name;
+         particle_list[s].num_species  = g_param_yt.species_list[s].num_species;
+         particle_list[s].attr_list    = new yt_attribute [ particle_list[s].num_species ];
+      }
+      g_param_yt.particle_list   = particle_list;      
+   }
+   else {
+      // don't need to load particle, set as NULL.
+      g_param_yt.particle_list   = NULL;
+   }
 
 
 // Organize other information, for later runtime usage

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -127,10 +127,10 @@ int yt_set_parameter( yt_param_yt *param_yt )
       yt_particle *particle_list = new yt_particle [ g_param_yt.num_species ];
       for ( int s = 0; s < g_param_yt.num_species; s++ ){
          particle_list[s].species_name = g_param_yt.species_list[s].species_name;
-         particle_list[s].num_species  = g_param_yt.species_list[s].num_species;
-         particle_list[s].attr_list    = new yt_attribute [ particle_list[s].num_species ];
+         particle_list[s].num_attr     = g_param_yt.species_list[s].num_attr;
+         particle_list[s].attr_list    = new yt_attribute [ particle_list[s].num_attr ];
       }
-      g_param_yt.particle_list   = particle_list;      
+      g_param_yt.particle_list   = particle_list;
    }
    else {
       // don't need to load particle, set as NULL.

--- a/src/yt_set_parameter.cpp
+++ b/src/yt_set_parameter.cpp
@@ -34,19 +34,11 @@ int yt_set_parameter( yt_param_yt *param_yt )
 
 // check if libyt has free all the resource in previous inline-analysis
    if ( !g_param_libyt.free_gridsPtr ){
-      YT_ABORT( "Please invoke yt_free_gridsPtr() before calling %s() for next iteration!\n", __FUNCTION__ );
+      log_warning( "Please invoke yt_free_gridsPtr() before calling %s() for next iteration!\n", __FUNCTION__ );
+      YT_ABORT("Overwrite existing parameters may leads to memory leak, please called yt_free_gridsPtr() first!\n");
    }
 
    log_info( "Setting YT parameters ...\n" );
-
-// check if this function has been called previously.
-// Abort if yes, since overwrite may leads to memory leakage.
-   if ( g_param_libyt.param_yt_set )
-   {
-      log_warning( "%s() has been called already!\n", __FUNCTION__ );
-      log_warning( "==> Are you trying to overwrite existing parameters?\n" );
-      YT_ABORT("Overwrite existing parameters may leads to memory leak, please called yt_free_gridsPtr() first!\n");
-   }
 
 
 // reset all cosmological parameters to zero for non-cosmological datasets


### PR DESCRIPTION
## Main Goal
### Support Particle Operation in [`yt`](https://yt-project.org/)
- Load discrete particle data only when `yt` ask to.
- Since some particle operations are not paralleled in `yt`, this PR has only successfully run with MPI rank = 1. So need further test on MPI rank > 1, once it's paralleled.
  - For now, if the grid id `g.id` cannot be found on one MPI rank, then the whole process will terminate. 
    - This will not be a problem if `yt` operation is paralleled, such that it will only ask for data locate on this rank.
    - Another possible way is that `yt` ask for the same data on every rank, and ask them to handle those possessed grids. Then gather all the information, including one does not handle any grids. If this is the case, we should return `None` if `g.id` not found on local grids, instead of terminating the process. _(Not sure, just my guessing.)_
- Change `yt_grid` struct, in order to store particle counts in different types.
### Miscellaneous Update
- Hide `yt_hierarchy` from user. This structure is only meant to be temporary used in `libyt`.
- Set unit default as empty string `""`.
- Initialize and free array `field_list`, `particle_list`, `grids_local` in the condition of `num_fields > 0` and `num_species > 0`. In order to avoid `new <type> [0]`.