### PR TITLE
Update 2021.9.7

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -270,6 +270,9 @@ int main( int argc, char *argv[] )
       for ( int v=0; v<4; v++ ){
          particle_list[1].attr_list[v].attr_name = attr_name[v];     // Fill in for particle species "par2"
       }
+      particle_list[1].coor_x = attr_name[0];
+      particle_list[1].coor_y = attr_name[1];
+      particle_list[1].coor_z = attr_name[2];
 
 //    ============================================================
 //    5. Get pointer to local grids array, then set up local grids

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -188,7 +188,9 @@ int main( int argc, char *argv[] )
       // Since we are now using "gamer" as frontend, we need to set code specific parameter.
       // mhd must be defined in gamer frontend fields.py.
       const int mhd = 0;   
-      yt_add_user_parameter_int   ( "mhd", 1, &mhd);
+      yt_add_user_parameter_int("mhd", 1, &mhd);
+      const int srhd = 0;
+      yt_add_user_parameter_int("srhd", 1, &srhd);
 
       // You can also input your own code specific parameter to match your frontend's fields.py
       const  int   user_int        = 1;

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -22,8 +22,7 @@ def yt_inline_ProfilePlot():
         profile.save()
     
 def yt_inline_ParticlePlot():
-    # [Caution] YT Particle Plot does not support parallelism for now
-    #           So we run mpirun -np 1
+    # [Caution] YT Particle Plot does not support parallelism for now.
     ds = yt.frontends.libyt.libytDataset()
     
     ## ParticleProjectionPlot

--- a/example/inline_script.py
+++ b/example/inline_script.py
@@ -22,18 +22,19 @@ def yt_inline_ProfilePlot():
         profile.save()
     
 def yt_inline_ParticlePlot():
-    # [Caution] YT Particle Plot does not support parallelism for now.
-    ds = yt.frontends.libyt.libytDataset()
+    pass
+    # # [Caution] YT Particle Plot does not support parallelism for now.
+    # ds = yt.frontends.libyt.libytDataset()
     
-    ## ParticleProjectionPlot
-    #==========================
-    # par = yt.ParticleProjectionPlot(ds, "z")
+    # ## ParticleProjectionPlot
+    # #==========================
+    # # par = yt.ParticleProjectionPlot(ds, "z")
 
-    ## ParticlePlot
-    #==========================
-    par = yt.ParticlePlot(ds, "particle_position_x", "particle_position_y", "Level", center = 'c')
+    # ## ParticlePlot
+    # #==========================
+    # par = yt.ParticlePlot(ds, "particle_position_x", "particle_position_y", "Level", center = 'c')
 
-    par.save()
+    # par.save()
 
 def test_user_parameter():
     import libyt

--- a/include/yt_prototype.h
+++ b/include/yt_prototype.h
@@ -41,6 +41,7 @@ int  create_libyt_module();
 int  init_python( int argc, char *argv[] );
 int  init_libyt_module();
 int  allocate_hierarchy();
+int  get_npy_dtype( yt_dtype data_type, int *npy_dtype );
 int  append_grid( yt_grid *grid );
 int  check_sum_num_grids_local_MPI( int NRank, int * &num_grids_local_MPI );
 int  check_field_list();

--- a/include/yt_type.h
+++ b/include/yt_type.h
@@ -17,7 +17,7 @@ typedef unsigned long int  ulong;
 
 // enumerate types
 enum yt_verbose { YT_VERBOSE_OFF=0, YT_VERBOSE_INFO=1, YT_VERBOSE_WARNING=2, YT_VERBOSE_DEBUG=3 };
-enum yt_dtype   { YT_DTYPE_UNKNOWN=0, YT_FLOAT=1, YT_DOUBLE=2, YT_INT=3 };
+enum yt_dtype : int { YT_FLOAT=0, YT_DOUBLE, YT_INT, YT_LONG, YT_DTYPE_UNKNOWN };
 
 
 // structures

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -132,9 +132,18 @@ struct yt_field
    		YT_ABORT("In field [%s], unknown field_define_type [%s]!\n", field_name, field_define_type);
    	}
 
-   	// Check if field_dtype is set.
-   	if ( field_dtype != YT_FLOAT && field_dtype != YT_DOUBLE && field_dtype != YT_INT ){
-   		YT_ABORT("In field [%s], unknown field_dtype, should be one of these: YT_FLOAT, YT_DOUBLE, YT_INT!\n");
+   	// if field_dtype is set.
+   	bool check2 = false;
+   	for ( int yt_dtypeInt = YT_FLOAT; yt_dtypeInt < YT_DTYPE_UNKNOWN; yt_dtypeInt++ ){
+   		yt_dtype dtype = static_cast<yt_dtype>(yt_dtypeInt);
+   		if ( field_dtype == dtype ){
+   			check2 = true;
+   			break;
+   		}
+   	}
+   	if ( check2 == false && strcmp(field_define_type, "derived_func") != 0 ){
+   		YT_ABORT("In field [%s], field_define_type == %s, but field_dtype not set!\n", 
+   			       field_name, field_define_type);
    	}
 
    	// Raise warning if derived_func == NULL and field_define_type is set to "derived_func".

--- a/include/yt_type_field.h
+++ b/include/yt_type_field.h
@@ -108,7 +108,7 @@ struct yt_field
 //                  (2) field_define_type can only be : "cell-centered", "face-centered", "derived_func".
 //                  (3) Check if field_dtype is set.
 //                  (4) Raise warning if derived_func == NULL and field_define_type is set to "derived_func".
-//               2. Used in yt_commit_grids()
+//               2. Used in check_field_list()
 // 
 // Parameter   : None
 // ======================================================================================================

--- a/include/yt_type_grid.h
+++ b/include/yt_type_grid.h
@@ -130,7 +130,7 @@ struct yt_grid
    //
    // Note        :  1. This function does not perform checks that depend on the input
    //                   YT parameters (e.g., whether left_edge lies within the simulation domain)
-   //                   ==> These checks are performed in yt_commit_grids()
+   //                   ==> These checks are performed in check_grid()
    //                2. If check needs information other than grid info, we will do it elsewhere.
    //
    // Parameter   :  None

--- a/include/yt_type_param_libyt.h
+++ b/include/yt_type_param_libyt.h
@@ -19,6 +19,7 @@
 // Data Member :  [public ] ==> Set by users when calling yt_init()
 //                verbose : Verbose level
 //                script  : Name of the YT inline analysis script (without the .py extension)
+//                counter : Number of rounds doing inline-analysis
 //                check_data: Check the input data (ex: hierarchy, grid information...), if it is true.
 //
 //                [private] ==> Set and used by libyt internally
@@ -41,8 +42,8 @@ struct yt_param_libyt
 // ===================================================================================
    yt_verbose verbose;
    const char *script;
+   long       counter;   
    bool       check_data;
-
 
 // private data members
 // ===================================================================================
@@ -53,7 +54,7 @@ struct yt_param_libyt
    bool  get_gridsPtr;
    bool  commit_grids;
    bool  free_gridsPtr;
-   long  counter;
+   
 
 
    //===================================================================================
@@ -67,11 +68,13 @@ struct yt_param_libyt
    yt_param_libyt()
    {
 
-//    set defaults
-      verbose = YT_VERBOSE_WARNING;
-      script  = "yt_inline_script";
+//    Set by user
+      verbose    = YT_VERBOSE_WARNING;
+      script     = "yt_inline_script";
+      counter    = 0;
       check_data = true;
 
+//    Set by libyt
       libyt_initialized  = false;
       param_yt_set       = false;
       get_fieldsPtr      = false;
@@ -79,8 +82,6 @@ struct yt_param_libyt
       get_gridsPtr       = false;
       commit_grids       = false;
       free_gridsPtr      = true;
-      counter            = 0;
-
    } // METHOD : yt_param_libyt
 
 

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -43,8 +43,7 @@ struct yt_species
 //                   ( "name", ("units", ["alias1", "alias2"], "display_name"))
 //
 // Data Member :  char     *attr_name             : Particle label name, which in yt, it is its attribute.
-//                yt_dtype  attr_dtype            : Attribute's data type. For now, it is type yt_dtype:
-//                                                  (1) YT_FLOAT (2) YT_DOUBLE (3) YT_INT
+//                yt_dtype  attr_dtype            : Attribute's data type. Should be yt_dtype.
 //                char     *attr_unit             : Set attr_unit if needed, if not set, it will search 
 //                                               for XXXFieldInfo. Where XXX is set by g_param_yt.frontend.
 //                int       num_attr_name_alias   : Set attribute name to alias, number of the aliases.
@@ -110,7 +109,7 @@ struct yt_attribute
 // 
 // Note        : 1. Validate data member value in one yt_attribute struct.
 //                  (1) attr_name is set, and != NULL.
-//                  (2) attr_dtype is one of yt_dtype = {YT_FLOAT, YT_DOUBLE, YT_INT}.
+//                  (2) attr_dtype is one of yt_dtype.
 // 
 // Parameter   : None
 // ======================================================================================================
@@ -120,12 +119,20 @@ struct yt_attribute
    			YT_ABORT("attr_name is not set!\n");
    		}
 
-   		// attr_dtype is one of yt_dtype = {YT_FLOAT, YT_DOUBLE, YT_INT}.
-   		if ( attr_dtype != YT_FLOAT && attr_dtype != YT_DOUBLE && attr_dtype != YT_INT ){
-   			YT_ABORT("In attr [%s], unknown attr_dtype, should be one of these: YT_FLOAT, YT_DOUBLE, YT_INT!\n", attr_name);
+   		// attr_dtype is one of yt_dtype
+   		bool valid = false;
+   		for ( int yt_dtypeInt = YT_FLOAT; yt_dtypeInt < YT_DTYPE_UNKNOWN; yt_dtypeInt++ ){
+   			yt_dtype dtype = static_cast<yt_dtype>(yt_dtypeInt);
+   			if ( attr_dtype == dtype ){
+   				valid = true;
+   				break;
+   			}
+   		}
+   		if ( valid == false ){
+   			YT_ABORT("In attr [%s], unknown attr_dtype!\n", attr_name);
    		}
 
-      	return YT_SUCCESS;
+   		return YT_SUCCESS;
    	}
 
 
@@ -268,13 +275,13 @@ struct yt_particle
 
    		// if didn't input coor_x/y/z, yt cannot function properly for this particle.
    		if ( coor_x == NULL ){
-   			log_warning("In particle species [ %s ], attribute name of coordinate x coor_x not set!\n", species_name);
+   			YT_ABORT("In particle species [ %s ], attribute name of coordinate x coor_x not set!\n", species_name);
    		}
    		if ( coor_y == NULL ){
-   			log_warning("In particle species [ %s ], attribute name of coordinate y coor_y not set!\n", species_name);
+   			YT_ABORT("In particle species [ %s ], attribute name of coordinate y coor_y not set!\n", species_name);
    		}
    		if ( coor_z == NULL ){
-   			log_warning("In particle species [ %s ], attribute name of coordinate z coor_z not set!\n", species_name);
+   			YT_ABORT("In particle species [ %s ], attribute name of coordinate z coor_z not set!\n", species_name);
    		}
 
    		// if didn't input get_attr, yt cannot function properly for this particle.

--- a/include/yt_type_particle.h
+++ b/include/yt_type_particle.h
@@ -238,6 +238,7 @@ struct yt_particle
 //                  (5) call yt_attribute validate for each attr_list elements.
 //                  (6) raise log_warning if coor_x, coor_y, coor_z is not set.
 //                  (7) raise log_warning if get_attr not set.
+//               2. Used inside check_particle_list().
 // 
 // Parameter   : None
 // ======================================================================================================

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ CC_FILE := yt_init.cpp  yt_finalize.cpp  yt_set_parameter.cpp  yt_inline.cpp  yt
            yt_commit_grids.cpp yt_get_gridsPtr.cpp yt_get_fieldsPtr.cpp yt_get_particlesPtr.cpp         \
            yt_free_gridsPtr.cpp yt_getGridInfo.cpp
 CC_FILE += logging.cpp  init_python.cpp  init_libyt_module.cpp  add_dict.cpp  allocate_hierarchy.cpp    \
-		   check_data.cpp append_grid.cpp
+		   check_data.cpp append_grid.cpp get_npy_dtype.cpp
 
 
 # library name

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -71,7 +71,7 @@ int append_grid( yt_grid *grid ){
          else {
             int grid_dtype;
             if ( get_npy_dtype((grid->field_data)[v].data_dtype, &grid_dtype) != YT_SUCCESS ){
-               YT_ABORT("Unknown yt_dtype, cannot match it to NumPy Enumerate type.\n");
+               YT_ABORT("Unknown yt_dtype, cannot get the NumPy enumerate type properly.\n");
             }
             // get the dimension of the input array from the (grid->field_data)[v]
             npy_intp grid_dims[3] = { (grid->field_data)[v].data_dim[0],

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -38,7 +38,7 @@ int append_grid( yt_grid *grid ){
    FILL_ARRAY( "grid_parent_id",      &grid->parent_id,           1, npy_long   );
    FILL_ARRAY( "grid_levels",         &grid->level,               1, npy_long   );
    FILL_ARRAY( "proc_num",            &grid->proc_num,            1, npy_int    );
-   log_debug( "Inserting grid [%15ld] info to libyt.hierarchy ... done\n", grid->id );
+   log_debug( "Inserting grid [%ld] info to libyt.hierarchy ... done\n", grid->id );
 
 // export grid data to libyt.grid_data as "libyt.grid_data[grid_id][field_list.field_name][field_data.data_ptr]"
    PyObject *py_grid_id, *py_field_labels, *py_field_data;
@@ -120,7 +120,7 @@ int append_grid( yt_grid *grid ){
             // call decref since PyDict_SetItemString() returns a new reference
             Py_DECREF( py_field_data );
 
-            log_debug( "Inserting grid [%15ld] field data [%s] to libyt.grid_data ... done\n", 
+            log_debug( "Inserting grid [%ld] field data [%s] to libyt.grid_data ... done\n", 
                         grid->id, g_param_yt.field_list[v].field_name );
          }
 

--- a/src/append_grid.cpp
+++ b/src/append_grid.cpp
@@ -69,15 +69,9 @@ int append_grid( yt_grid *grid ){
                         grid->id, g_param_yt.field_list[v].field_name );
          }
          else {
-            int grid_dtype = NPY_DOUBLE;
-            if ( (grid->field_data)[v].data_dtype == YT_FLOAT ){
-               grid_dtype = NPY_FLOAT;
-            }
-            else if ( (grid->field_data)[v].data_dtype == YT_DOUBLE ){
-               grid_dtype = NPY_DOUBLE;
-            }
-            else if ( (grid->field_data)[v].data_dtype == YT_INT ){
-               grid_dtype = NPY_INT;
+            int grid_dtype;
+            if ( get_npy_dtype((grid->field_data)[v].data_dtype, &grid_dtype) != YT_SUCCESS ){
+               YT_ABORT("Unknown yt_dtype, cannot match it to NumPy Enumerate type.\n");
             }
             // get the dimension of the input array from the (grid->field_data)[v]
             npy_intp grid_dims[3] = { (grid->field_data)[v].data_dim[0],

--- a/src/check_data.cpp
+++ b/src/check_data.cpp
@@ -233,6 +233,10 @@ int check_grid(){
 // Note        :  1. Use inside yt_commit_grids()
 // 			      2. Check that the hierarchy is correct, even though we didn't build a parent-children 
 //                   map.
+//                  (1) Check every grid id are unique.
+//                  (2) Check if all grids with level > 0, have a good parent id.
+//                  (3) Check if children grids' edge fall between parent's.
+//                  (4) Check parent's level = children level - 1.
 // 				  
 // Parameter   :  yt_hierarchy * &hierarchy : Contain full hierarchy
 //

--- a/src/get_npy_dtype.cpp
+++ b/src/get_npy_dtype.cpp
@@ -1,0 +1,44 @@
+#include "yt_combo.h"
+#include "libyt.h"
+
+//-------------------------------------------------------------------------------------------------------
+// Function    :  get_npy_dtype
+// Description :  Match from yt_dtype YT_* to NumPy enumerate type.
+//
+// Note        :  1. This function matches yt_dtype to NumPy enumerate type, and will write result in 
+//                   npy_dtype.
+//                2. If you want to add new type to wrap your data, add it here. So that libyt knows how
+//                   to match it to NumPy enumerate type.
+//                3.   yt_dtype      NumPy Enumerate Type
+//                  ========================================
+//                     YT_FLOAT            NPY_FLOAT
+//                     YT_DOUBLE           NPY_DOUBLE
+//                     YT_INT              NPY_INT
+//                     YT_LONG             NPY_LONG
+//
+// Parameter   :  data_type : yt_dtype, YT_*.
+//                npy_dtype : NumPy enumerate data type.
+//
+// Return      :  YT_SUCCESS or YT_FAIL
+//-------------------------------------------------------------------------------------------------------
+int get_npy_dtype( yt_dtype data_type, int *npy_dtype ){
+
+	if ( data_type == YT_FLOAT ){
+		*npy_dtype = NPY_FLOAT;
+	}
+	else if ( data_type == YT_DOUBLE ){
+		*npy_dtype = NPY_DOUBLE;
+	}
+	else if ( data_type == YT_INT ){
+		*npy_dtype = NPY_INT;
+	}
+	else if ( data_type == YT_LONG ){
+		*npy_dtype = NPY_LONG;
+	}
+	else{
+		*npy_dtype = -1;
+		return YT_FAIL;
+	}
+
+	return YT_SUCCESS;
+}

--- a/src/get_npy_dtype.cpp
+++ b/src/get_npy_dtype.cpp
@@ -22,7 +22,7 @@
 // Return      :  YT_SUCCESS or YT_FAIL
 //-------------------------------------------------------------------------------------------------------
 int get_npy_dtype( yt_dtype data_type, int *npy_dtype ){
-
+	
 	if ( data_type == YT_FLOAT ){
 		*npy_dtype = NPY_FLOAT;
 	}
@@ -36,6 +36,23 @@ int get_npy_dtype( yt_dtype data_type, int *npy_dtype ){
 		*npy_dtype = NPY_LONG;
 	}
 	else{
+		// Safety check that data_type is one of yt_dtype, 
+		// so that if we cannot match a NumPy Enum Type, then it must be user forgot to implement here.
+		bool valid = false;
+		for ( int yt_dtypeInt = YT_FLOAT; yt_dtypeInt < YT_DTYPE_UNKNOWN; yt_dtypeInt++ ){
+			yt_dtype dtype = static_cast<yt_dtype>(yt_dtypeInt);
+			if ( data_type == dtype ){
+				valid = true;
+				break;
+			}
+		}
+		if ( valid == true ){
+			log_error("You should also match your new yt_dtype to NumPy enumerate type in get_npy_dtype function.\n");
+		}
+		else{
+			log_error("If you want to implement your new yt_dtype, you should modify both yt_dtype Enum and get_npy_dtype function.\n");
+		}
+		
 		*npy_dtype = -1;
 		return YT_FAIL;
 	}

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -251,8 +251,12 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
     npy_intp dims[1] = { array_length };
     void     *output;
 
+    if ( get_npy_dtype(attr_dtype, &typenum) != YT_SUCCESS ){
+        PyErr_Format(PyExc_ValueError, "Unknown yt_dtype, cannot get the NumPy enumerate type properly.\n");
+        return NULL;
+    }
+
     if ( attr_dtype == YT_INT ){
-        typenum = NPY_INT;
         output = malloc( array_length * sizeof(int) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((int *)output)[i] = 0;
@@ -260,7 +264,6 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
         get_attr(gid, attr_name, output);
     }
     else if ( attr_dtype == YT_FLOAT ){
-        typenum = NPY_FLOAT;
         output = malloc( array_length * sizeof(float) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((float *)output)[i] = 0;
@@ -268,7 +271,6 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
         get_attr(gid, attr_name, output);
     }
     else if ( attr_dtype == YT_DOUBLE ){
-        typenum = NPY_DOUBLE;
         output = malloc( array_length * sizeof(double) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((double *)output)[i] = 0;

--- a/src/init_libyt_module.cpp
+++ b/src/init_libyt_module.cpp
@@ -256,28 +256,36 @@ static PyObject* libyt_particle_get_attr(PyObject *self, PyObject *args){
         return NULL;
     }
 
+    // Initialize output array
     if ( attr_dtype == YT_INT ){
         output = malloc( array_length * sizeof(int) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((int *)output)[i] = 0;
         }
-        get_attr(gid, attr_name, output);
     }
     else if ( attr_dtype == YT_FLOAT ){
         output = malloc( array_length * sizeof(float) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((float *)output)[i] = 0;
         }
-        get_attr(gid, attr_name, output);
     }
     else if ( attr_dtype == YT_DOUBLE ){
         output = malloc( array_length * sizeof(double) );
         for ( long i = 0; i < array_length; i++ ){ 
             ((double *)output)[i] = 0;
         }
-        get_attr(gid, attr_name, output);
     }
+    else if ( attr_dtype == YT_LONG ){
+        output = malloc( array_length * sizeof(long) );
+        for ( long i = 0; i < array_length; i++ ){
+            ((long *)output)[i] = 0;
+        }
+    }
+    
+    // Call get_attr function pointer    
+    get_attr(gid, attr_name, output);
 
+    // Wrap the output and return back to python
     PyObject *outputNumpyArray = PyArray_SimpleNewFromData(nd, dims, typenum, output);
     PyArray_ENABLEFLAGS( (PyArrayObject*) outputNumpyArray, NPY_ARRAY_OWNDATA);
 

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -275,7 +275,9 @@ int yt_commit_grids()
       }
 
       // Append grid to YT
-      append_grid( &grid_combine );
+      if ( append_grid( &grid_combine ) != YT_SUCCESS ){
+         YT_ABORT("Failed to append grid [ %ld ]!\n", grid_combine.id);
+      }
    }
 
    log_debug( "Append grids to libyt.grid_data ... done!\n" );

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -107,36 +107,6 @@ int yt_commit_grids()
                       grid.id, grid.particle_count_list[s], g_param_yt.particle_list[s].species_name);
          }
       }
-
-      // Deal with field_data in grid
-      for (int v = 0; v < g_param_yt.num_fields; v++){
-
-         // (2) set data_dim in field_data if field_define_type == "cell-centered"
-         if ( strcmp(g_param_yt.field_list[v].field_define_type, "cell-centered") == 0 ){
-            // set the field_data data_dim, base on grid_dimensions and swap_axes
-            if ( g_param_yt.field_list[v].swap_axes == true ){
-               grid.field_data[v].data_dim[0] = grid.grid_dimensions[2];
-               grid.field_data[v].data_dim[1] = grid.grid_dimensions[1];
-               grid.field_data[v].data_dim[2] = grid.grid_dimensions[0];
-            }
-            else {
-               grid.field_data[v].data_dim[0] = grid.grid_dimensions[0];
-               grid.field_data[v].data_dim[1] = grid.grid_dimensions[1];
-               grid.field_data[v].data_dim[2] = grid.grid_dimensions[2];
-            }
-         }
-
-         // (3) Check field_data data_dtype, if it is not one of enum yt_dtype or YT_DTYPE_UNKNOWN, set to field_dtype.
-         if ( grid.field_data[v].data_dtype == YT_DTYPE_UNKNOWN ){
-            grid.field_data[v].data_dtype = g_param_yt.field_list[v].field_dtype;
-         }
-         else if ( grid.field_data[v].data_dtype != YT_FLOAT && grid.field_data[v].data_dtype != YT_DOUBLE &&
-                   grid.field_data[v].data_dtype != YT_INT ){
-            log_warning("Grid [%ld], field_data [%s], data_dtype is not one of YT_FLOAT, YT_DOUBLE, YT_INT, so set to field_dtype.\n", 
-                         grid.id, g_param_yt.field_list[v].field_name);
-            grid.field_data[v].data_dtype = g_param_yt.field_list[v].field_dtype;
-         }
-      }
    }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -166,7 +166,7 @@ int yt_commit_grids()
 
    for (int i = 0; i < NRank; i++){
       offsets[i] = 0;
-      accumulate = 0
+      accumulate = 0;
       for (int j = mpi_start; j < i; j++){
          offsets[i] += g_param_yt.num_grids_local_MPI[j];
          accumulate += g_param_yt.num_grids_local_MPI[j];

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -10,13 +10,12 @@
 //                2. Must call yt_get_fieldsPtr (if num_fields>0), yt_get_particlesPtr (if num_species>0), 
 //                   yt_get_gridsPtr, which gets data info from user.
 //                3. Check the local grids, field list, and particle list. 
-//                4. Sum up particle_count_list in each individual grid and store in grid_particle_count.
-//                5. Force the "cell-centered" field data_dim read from grid_dimensions.
-//                6. Append field_list info and particle_list info to libyt.param_yt['field_list'] and 
+//                4. Append field_list info and particle_list info to libyt.param_yt['field_list'] and 
 //                   libyt.param_yt['particle_list'].
-//                7. Gather hierarchy in different rank, and check hierarchy in check_hierarchy().
-//                8. Pass the grids and hierarchy to YT in function append_grid().
-//                9. We assume that one grid contains all the fields belong to that grid.
+//                5. Sum up particle_count_list in each individual grid and store in grid_particle_count.
+//                6. Gather hierarchy in different rank, and check hierarchy in check_hierarchy().
+//                7. Pass the grids and hierarchy to YT in function append_grid().
+//                8. We assume that one grid contains all the fields belong to that grid.
 //
 // Parameter   :
 //

--- a/src/yt_commit_grids.cpp
+++ b/src/yt_commit_grids.cpp
@@ -225,6 +225,14 @@ int yt_commit_grids()
          }
       }
    }
+// The code above does not consider NRank = 1. So we need to explicitly support NRank = 1.
+// I know this is ugly, so just bear with me.
+   if ( NRank == 1 ){
+      recv_counts[0] = g_param_yt.num_grids_local_MPI[0];
+      offsets[0] = 0;
+      MPI_Gatherv(hierarchy_local, g_param_yt.num_grids_local, yt_hierarchy_mpi_type,
+                  hierarchy_full, recv_counts, offsets, yt_hierarchy_mpi_type, RootRank, MPI_COMM_WORLD);
+   }
 
 // Check that the hierarchy are correct, do the test on RootRank only
    if ( g_param_libyt.check_data == true && MyRank == RootRank ){

--- a/src/yt_init.cpp
+++ b/src/yt_init.cpp
@@ -35,13 +35,16 @@ int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt )
 
 // store user-provided parameters to a libyt internal variable
 // --> better do it **before** calling any log function since they will query g_param_libyt.verbose
-   g_param_libyt.verbose = param_libyt->verbose;
-   g_param_libyt.script  = param_libyt->script;
-   g_param_libyt.counter = param_libyt->counter;   // useful during restart, where the initial counter can be non-zero
+   g_param_libyt.verbose    = param_libyt->verbose;
+   g_param_libyt.script     = param_libyt->script;
+   g_param_libyt.counter    = param_libyt->counter;   // useful during restart, where the initial counter can be non-zero
+   g_param_libyt.check_data = param_libyt->check_data;
 
    log_info( "Initializing libyt ...\n" );
    log_debug( "   verbose = %d\n", g_param_libyt.verbose );
-   log_debug( "   script  = %s\n", g_param_libyt.script );
+   log_debug( "    script = %s\n", g_param_libyt.script  );
+   log_debug( "   counter = %ld\n", g_param_libyt.counter);
+   log_debug( "check_data = %s\n", (g_param_libyt.check_data ? "true" : "false"));
 
 // create libyt module, should be before init_python
    if ( create_libyt_module() == YT_FAIL ) {

--- a/src/yt_init.cpp
+++ b/src/yt_init.cpp
@@ -41,10 +41,10 @@ int yt_init( int argc, char *argv[], const yt_param_libyt *param_libyt )
    g_param_libyt.check_data = param_libyt->check_data;
 
    log_info( "Initializing libyt ...\n" );
-   log_debug( "   verbose = %d\n", g_param_libyt.verbose );
-   log_debug( "    script = %s\n", g_param_libyt.script  );
-   log_debug( "   counter = %ld\n", g_param_libyt.counter);
-   log_debug( "check_data = %s\n", (g_param_libyt.check_data ? "true" : "false"));
+   log_info( "   verbose = %d\n", g_param_libyt.verbose );
+   log_info( "    script = %s\n", g_param_libyt.script  );
+   log_info( "   counter = %ld\n", g_param_libyt.counter);
+   log_info( "check_data = %s\n", (g_param_libyt.check_data ? "true" : "false"));
 
 // create libyt module, should be before init_python
    if ( create_libyt_module() == YT_FAIL ) {


### PR DESCRIPTION
### Update 2021.9.7
- Fix bug `MPI_Gatherv` not support send count > INT_MAX.
- Simplify choosing data dimension and data type between `data_dim` and `grid_dimensions`, `data_dtype` and `field_dtype`. This is now all done inside `append_grid.cpp`.
- If `data_ptr = NULL`, `libyt` shouldn't abort when `data_dtype` or `field_dtype` is not set and `check_data==false`. We don't need to wrap this array, hence no need to set data type.
- Support more particle type, YT_LONG.
  - User can also extend their new data type, see [Add New Particle Data Type](https://hackmd.io/@Viukb0eMS-aeoZQudVyJ2w/ryCYwu0xF/%2FLAMTxFrTQO-f_dQT2AXT7g#Add-New-Particle-Data-Type).
- Update `libyt/example` to match newest `yt`.
- New function `get_npy_dtype` to match `yt_dtype` to NumPy Enumerate Type. So that user can add new data type more eifficiently.
  - See how to add new type at [Add New NumPy Enumerate Type](https://hackmd.io/@Viukb0eMS-aeoZQudVyJ2w/ryCYwu0xF/%2FLAMTxFrTQO-f_dQT2AXT7g#Add-New-NumPy-Enumerate-Type).
  - Use Enum Loop to check if the input `yt_dtype` is valid or not.