### PR TITLE
Use make install and support MacOS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -87,6 +87,7 @@ jobs:
           sed -i 's@$(YOUR_PYTHON_VERSION)@"${{ matrix.python-version }}"@' Makefile
           make clean
           make
+          make install
           echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Prepare Test Script

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -52,7 +52,7 @@ jobs:
           pip install mpi4py yt
           cd $GITHUB_WORKSPACE
           cd ..
-          git clone --depth 1 -b libyt-dev --single-branch "https://github.com/cindytsai/yt_libyt.git" yt_libyt
+          git clone https://github.com/data-exp-lab/yt_libyt.git
           cd yt_libyt
           pip install .
           

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
         - "main"
-        - "doc"
     paths:
         - "doc/**"
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# libyt
-[![build-test](https://github.com/cindytsai/libyt/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/cindytsai/libyt/actions/workflows/build-test.yml)
+[![build-test](https://github.com/calab-ntu/libyt/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/calab-ntu/libyt/actions/workflows/build-test.yml)
 
- 
+
 `libyt` is an open source C++ library for simulation, that allows researchers to analyze and visualize data using [`yt`](https://yt-project.org/) or other Python packages in parallel during simulation runtime. In this way, we can skip the step of writing data to local disk before doing analysis using Python. This greatly reduce the disk usage, and increase the temporal resolution.
 
-This is my personal repo. It is only for developing purpose.
-
-- **Documents (my version)**: https://cindytsai.github.io/libyt/
+- **Documents**: https://calab-ntu.github.io/libyt/
 - **See `libyt` working progress**: [Project Board](https://github.com/calab-ntu/libyt/projects/1)
+
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,8 @@
 # libyt
-[![build-test](https://github.com/cindytsai/libyt/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/cindytsai/libyt/actions/workflows/build-test.yml)
+[![build-test](https://github.com/calab-ntu/libyt/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/calab-ntu/libyt/actions/workflows/build-test.yml)
 
-`libyt` is a C library for C/C++ simulation to use [`yt`](https://yt-project.org/) and Python to do in situ analysis, while the simulation is still running. In this way, we can skip the step of writing data to local disk before any analysis using Python can happen. This greatly reduce the disk usage, and increase the temporal resolution.
+ 
+`libyt` is an open source C++ library for simulation, that allows researchers to analyze and visualize data using [`yt`](https://yt-project.org/) or other Python packages in parallel during simulation runtime. In this way, we can skip the step of writing data to local disk before doing analysis using Python. This greatly reduce the disk usage, and increase the temporal resolution.
 
-- **Implement `libyt` into your code** :arrow_right:
-  - [Installation](#installation)
-  - [User Guide](#user-guide)
-  - [Example](#example)
-- **See `libyt` working progress** :arrow_right: [Project Board](https://github.com/calab-ntu/libyt/projects/1)
-- **See how `libyt` is developed** :arrow_right: [`libyt` Milestone](https://hackmd.io/@Viukb0eMS-aeoZQudVyJ2w/ryCYwu0xF)
-- **Supported `yt` functionalities**:
-
-  |      `yt` Function       | Supported | Notes                                    |
-  |:------------------------:|:---------:|------------------------------------------|
-  |        `find_max`        |     V     |                                          |
-  |     `ProjectionPlot`     |     V     |                                          |
-  | `OffAxisProjectionPlot`  |     V     |                                          |
-  |       `SlicePlot`        |     V     |                                          |
-  |    `OffAxisSlicePlot`    |     V     |                                          |
-  |     `covering_grid`      |     V     |                                          |
-  |   1D `create_profile`    |     V     |                                          |
-  |   2D `create_profile`    |     V     |                                          |
-  |      `ProfilePlot`       |     V     |                                          |
-  |       `PhasePlot`        |     V     |                                          |
-  |        `LinePlot`        |     V     |                                          |
-  |      Halo Analysis       |           | Not test yet.                            |
-  |       Isocontours        |     V     |                                          |
-  |     `volume_render`      |     V     | Only when MPI size is even will it work. |
-  |      `ParticlePlot`      |     V     |                                          |
-  | `ParticleProjectionPlot` |     V     |                                          |
-
-
-## User Guide
-This guide will walk you through how to implement `libyt` into your code. And how you can convert your everyday used `yt` script to do inline-analysis. All the user guide are in [`doc`](./doc) folder.
-
-
-- Implement `libyt` to your code step by step
-  - [Initialize - `yt_initialize`](doc/libytAPI/Initialize.md#initialize)
-  - [Set `yt` Parameter - `yt_set_Parameters`](doc/libytAPI/SetYTParameter.md#set-yt-parameter)
-  - [Set Code Specific Parameter - `yt_set_UserParameter*`](doc/libytAPI/SetCodeSpecificParameter.md#set-code-or-user-specific-parameter)
-  - [Set Fields Information - `yt_get_FieldsPtr`](doc/libytAPI/FieldInfo/SetFieldsInformation.md#set-fields-information)
-  - [Set Particles Information - `yt_get_ParticlesPtr`](doc/libytAPI/SetParticlesInformation.md#set-particles-information)
-  - [Set Local Grids Information - `yt_get_GridsPtr`](doc/libytAPI/SetLocalGridsInformation.md#set-local-grids-information)
-  - [Commit Your Settings - `yt_commit`](doc/libytAPI/CommitYourSettings.md#commit-your-settings)
-  - [Perform Inline-Analysis - `yt_run_Function` and `yt_run_FunctionArguments`](doc/libytAPI/PerformInlineAnalysis.md#perform-inline-analysis)
-  - [Activate Interactive Mode - `yt_run_InteractiveMode`](doc/libytAPI/ActivateInteractiveMode.md#activate-interactive-mode) (Only available in interactive mode)
-  - [Free Resource - `yt_free`](doc/libytAPI/FreeResource.md#free-resource)
-  - [Finalize - `yt_finalize`](doc/libytAPI/Finalize.md#finalize)
-- [Inline Python Script](doc/InSituPythonAnalysis/InlinePythonScript.md#inline-python-script)
-
-## Example
-- A simple demo in [`libyt/example.cpp`](./example/example.cpp)
-- [`gamer`](https://github.com/gamer-project/gamer/tree/master/src/YT)
+- Documents: https://calab-ntu.github.io/libyt/
+- **See `libyt` working progress**: [Project Board](https://github.com/calab-ntu/libyt/projects/1)

--- a/doc/InSituPythonAnalysis/InteractivePythonPrompt.md
+++ b/doc/InSituPythonAnalysis/InteractivePythonPrompt.md
@@ -18,6 +18,8 @@ nav_order: 3
 
 > :information_source: We need `libyt` to be in [**interactive mode**]({% link HowToInstall.md %}#options).
 
+> :warning: Cannot use arrow keys or `Crtl+D` in interactive mode. 
+
 ## Status Board
 At the start of interactive mode, `libyt` prints the status board.
 Interactive Python prompt will list all the Python function it finds, either in imported script, or input from interactive Python prompt.

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -1,12 +1,12 @@
-title: libyt Documents (Dev)
-description: libyt documents, this site is mainly for developing.
+title: libyt Documents
+description: libyt documents
 theme: just-the-docs
 
-url: https://cindytsai.github.io/libyt/
+url: https://calab-ntu.github.io/libyt/
 
 # Aux links for the upper right navigation, create new tab once click
 aux_links:
-  cindytsai/libyt (dev): https://github.com/cindytsai/libyt
+  libyt GitHub : https://github.com/calab-ntu/libyt
 aux_links_new_tab: true
 
 # Heading anchor links appear on hover over h1-h6 tags in page content

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,19 +1,16 @@
 # Your path
-MPI_PATH       := $(YOUR_MPI_PATH)
-PYTHON_PATH    := $(YOUR_PYTHON_PATH)
-PYTHON_VERSION := $(YOUR_PYTHON_VERSION)
-READLINE_PATH  := $(YOUR_READLINE_PATH)
+####################################################################
+MPI_PATH := $(YOUR_MPI_PATH)
 
+# Compile example
+####################################################################
 BIN  := example
 FILE := example.cpp
 COMPILER := $(MPI_PATH)/bin/mpic++
 
 $(BIN): $(FILE)
-	$(COMPILER) -o $(BIN) $(FILE) -I../include \
-		-L$(READLINE_PATH)/lib -lreadline \
-	    -L$(PYTHON_PATH)/lib -lpython$(PYTHON_VERSION) \
-		-L../lib -lyt
-	
+	$(COMPILER) -o $(BIN) $(FILE) -I../include -L../lib -lyt -Wl,-rpath,../lib
+
 clean:
 	rm -f $(BIN)
 	rm -rf log

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,12 +1,18 @@
 # Your path
-MPI_PATH := $(YOUR_MPI_PATH)
+MPI_PATH       := $(YOUR_MPI_PATH)
+PYTHON_PATH    := $(YOUR_PYTHON_PATH)
+PYTHON_VERSION := $(YOUR_PYTHON_VERSION)
+READLINE_PATH  := $(YOUR_READLINE_PATH)
 
 BIN  := example
 FILE := example.cpp
 COMPILER := $(MPI_PATH)/bin/mpic++
 
 $(BIN): $(FILE)
-	$(COMPILER) -o $(BIN) $(FILE) -I../include -L../lib -lyt
+	$(COMPILER) -o $(BIN) $(FILE) -I../include \
+		-L$(READLINE_PATH)/lib -lreadline \
+	    -L$(PYTHON_PATH)/lib -lpython$(PYTHON_VERSION) \
+		-L../lib -lyt
 	
 clean:
 	rm -f $(BIN)

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -27,7 +27,7 @@
                               (Need to compile libyt with -DINTERACTIVE_MODE)
                           10. finish in-situ analysis, clean up libyt
     ----------------------------------------------------------------------------------
-    Finalization         11. finalize libyt
+    Finalization          11. finalize libyt
 
 [Compile and Run]
     1. Compile libyt and move libyt.so.* library to lib directory.

--- a/src/Makefile
+++ b/src/Makefile
@@ -48,12 +48,15 @@ CXX := $(MPI_PATH)/bin/mpicxx
 
 LIB := -L$(PYTHON_PATH)/lib -lpython$(PYTHON_VERSION)
 
+RPATH := -Wl,-rpath,$(PYTHON_PATH)/lib
+
 INCLUDE := -I../include -I$(PYTHON_PATH)/include/python$(PYTHON_VERSION) \
            -I$(NUMPY_PATH)/core/include \
            -I$(MPI_PATH)/include
 
 ifeq "$(filter -DINTERACTIVE_MODE, $(OPTIONS))" "-DINTERACTIVE_MODE"
 LIB     += -L$(READLINE_PATH)/lib -lreadline
+RPATH   += -Wl,-rpath,$(READLINE_PATH)/lib
 INCLUDE += -I$(READLINE_PATH)/include
 endif
 
@@ -76,10 +79,10 @@ $(OBJ_PATH)/%.o : %.cpp
 UNAME_S := $(shell uname -s)
 $(LIB_REALNAME) : $(OBJ)
 ifeq ($(UNAME_S),Linux)
-	$(CXX) -shared -Wl,-soname,$(LIB_SONAME) -o $@ $^ $(LIB)
+	$(CXX) -shared -Wl,-soname,$(LIB_SONAME) -o $@ $^ $(LIB) $(RPATH)
 endif
 ifeq ($(UNAME_S),Darwin)
-	$(CXX) -shared -Wl,-install_name,$(LIB_SONAME) -o $@ $^ $(LIB)
+	$(CXX) -shared -Wl,-install_name,$(LIB_SONAME) -o $@ $^ $(LIB) $(RPATH)
 endif
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,9 +55,12 @@ INCLUDE := -I../include -I$(PYTHON_PATH)/include/python$(PYTHON_VERSION) \
            -I$(MPI_PATH)/include
 
 ifeq "$(filter -DINTERACTIVE_MODE, $(OPTIONS))" "-DINTERACTIVE_MODE"
-LIB     += -L$(READLINE_PATH)/lib -lreadline
-RPATH   += -Wl,-rpath,$(READLINE_PATH)/lib
-INCLUDE += -I$(READLINE_PATH)/include
+	ifneq ($(READLINE_PATH),)
+		LIB     += -L$(READLINE_PATH)/lib
+		RPATH   += -Wl,-rpath,$(READLINE_PATH)/lib
+		INCLUDE += -I$(READLINE_PATH)/include
+	endif
+	LIB += -lreadline
 endif
 
 #CXXWARN_FLAG := -w1


### PR DESCRIPTION
## Use Make Install and Support Compile with MacOS

- How to install 
  ```bash
  make 
  make install
  ```
- Compile on macOS
  - Change `soname` to `install_name`
- Set `rpath` in `libyt.so.x` and `example`
  - This makes library or executable add the search path for linking library.