### PR TITLE
Valgrind and MISC

### DIFF
--- a/.github/workflows/cmake-build-test.yml
+++ b/.github/workflows/cmake-build-test.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           rm -rf build
-          cmake -B build -S . -DJUPYTER_KERNEL=ON
+          cmake -B build -S . -DJUPYTER_KERNEL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build build
           cmake --install build --prefix "${{ steps.strings.outputs.install-prefix }}/libyt-jupyter-on"
           cd "${{ steps.strings.outputs.install-prefix }}/libyt-jupyter-on"

--- a/.github/workflows/example-test-run.yml
+++ b/.github/workflows/example-test-run.yml
@@ -167,6 +167,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           ${{ matrix.install_dep_command }}
 
       - name: Set reusable strings
@@ -225,6 +226,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           ${{ matrix.install_dep_command }}
 
       - name: Configure and Build

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libreadline-dev tree
 
       - name: Set reusable strings
@@ -148,6 +149,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libreadline-dev
 
       - name: Set reusable strings
@@ -158,6 +160,7 @@ jobs:
 
       - name: Get valgrind from apt-get
         run: |
+          sudo apt-get update
           sudo apt-get install -y valgrind
 
       - name: Configure CMake (-DLIBYT_RUN_MEMORY_PROFILE=ON)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libreadline-dev lcov
 
       - name: Set reusable strings
@@ -144,6 +145,7 @@ jobs:
 
       - name: Install other dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libreadline-dev lcov
 
       - name: Set reusable strings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(INTERACTIVE_MODE  "Use interactive mode"                                 
 option(JUPYTER_KERNEL    "Use Jupyter notebook interface"                            OFF)
 option(SUPPORT_TIMER     "Support time profiling"                                    OFF)
 option(USE_PYBIND11      "Use pybind11"                                              OFF)
+option(SUPPORT_VALGRIND  "Support valgrind"                                          OFF)
 
 ## set paths ##
 # It is recommended that we always provide PYTHON_PATH and MPI_PATH.
@@ -20,6 +21,7 @@ option(USE_PYBIND11      "Use pybind11"                                         
 set(PYTHON_PATH    "" CACHE PATH "Path to Python installation prefix (Always)")
 set(MPI_PATH       "" CACHE PATH "Path to MPI installation prefix (-DSERIAL_MODE=OFF)")
 set(READLINE_PATH  "" CACHE PATH "Path to Readline installation prefix (-DINTERACTIVE_MODE=ON)")
+set(VALGRIND_PATH  "" CACHE PATH "Path to valgrind installation prefix (-DSUPPORT_VALGRIND=ON / -DLIBYT_RUN_MEMORY_PROFILE=ON)")
 
 ## set paths (optional) ##
 # libyt will get the dependencies if it cannot find one when needed.
@@ -40,8 +42,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(BUILD_SHARED_LIBS "Building using shared libraries"                           ON )
 
 # run test ##
-set(VALGRIND_PATH     "" CACHE PATH "Path to valgrind installation prefix (-DLIBYT_RUN_MEMORY_PROFILE=ON)")
-
 option(LIBYT_RUN_TEST                "Run unit test"                                 OFF)
 option(LIBYT_RUN_MEMORY_PROFILE      "Run memory profile"                            OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 # cmake-format: off
 ###### PROJECT Info #####################################################################
 project(LIBYT_PROJECT
-        VERSION 0.4.0
+        VERSION 0.5.0
         DESCRIPTION "In situ Python analysis tool using yt and Python"
 )
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "libyt"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.4.0
+PROJECT_NUMBER         = 0.5.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,8 +12,8 @@ project = 'libyt'
 copyright = '2024, Shin-Rong Tsai, Hsi-Yu Schive, Matthew Turk'
 author = 'Shin-Rong Tsai, Hsi-Yu Schive, Matthew Turk'
 
-version = "0.4.0"
-release = "0.4.0"
+version = "0.5.0"
+release = "0.5.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/index.md
+++ b/doc/index.md
@@ -3,7 +3,7 @@ hide-toc: true
 ---
 
 # libyt Documents
-{bdg-primary}`version 0.4.0`
+{bdg-primary}`version 0.5.0`
 
 `libyt` is an open source C library for simulation. 
 It is an in situ analysis tool that allows researchers to analyze and visualize data using [`yt`](https://yt-project.org/) or other Python packages in parallel during simulation runtime.

--- a/include/libyt.h
+++ b/include/libyt.h
@@ -7,7 +7,7 @@
  */
 
 #define LIBYT_MAJOR_VERSION 0
-#define LIBYT_MINOR_VERSION 4
+#define LIBYT_MINOR_VERSION 5
 #define LIBYT_MICRO_VERSION 0
 
 // declare libyt data type

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,14 +73,17 @@ set_option(INTERACTIVE_MODE)
 set_option(JUPYTER_KERNEL)
 set_option(SUPPORT_TIMER)
 set_option(USE_PYBIND11)
+set_option(SUPPORT_VALGRIND)
 
 # include dir
 target_include_directories(
   yt
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include
-    $<$<NOT:$<BOOL:${SERIAL_MODE}>>:${MPI_CXX_INCLUDE_DIRS}> ${Python_INCLUDE_DIRS}
+    $<$<NOT:$<BOOL:${SERIAL_MODE}>>:${MPI_CXX_INCLUDE_DIRS}>
+    ${Python_INCLUDE_DIRS}
     $<$<BOOL:${INTERACTIVE_MODE}>:${Readline_INCLUDE_DIR}>
+    $<$<BOOL:${SUPPORT_VALGRIND}>:${VALGRIND_PATH}/include>
 )
 
 # link lib

--- a/src/yt_commit.cpp
+++ b/src/yt_commit.cpp
@@ -102,6 +102,7 @@ int yt_commit() {
            LibytProcessControl::Get().mpi_rank_,
            stamp);
   VALGRIND_MONITOR_COMMAND(valgrind_cmd);
+  stamp = stamp + 1;
 #endif
 
   return YT_SUCCESS;

--- a/src/yt_commit.cpp
+++ b/src/yt_commit.cpp
@@ -95,12 +95,13 @@ int yt_commit() {
 #ifdef SUPPORT_VALGRIND
   // Dump valgrind detailed snapshot (ApJS paper purpose)
   static int stamp = 0;
-  char valgrind[100];
-  snprintf(valgrind,
+  char valgrind_cmd[100];
+  snprintf(valgrind_cmd,
            100,
            "detailed_snapshot MPI%dAfterCommit%d",
            LibytProcessControl::Get().mpi_rank_,
            stamp);
+  VALGRIND_MONITOR_COMMAND(valgrind_cmd);
 #endif
 
   return YT_SUCCESS;

--- a/src/yt_commit.cpp
+++ b/src/yt_commit.cpp
@@ -4,6 +4,10 @@
 #include "logging.h"
 #include "timer.h"
 
+#ifdef SUPPORT_VALGRIND
+#include <valgrind/valgrind.h>
+#endif
+
 /**
  * \defgroup api_yt_commit libyt API: yt_commit
  * \fn int yt_commit()
@@ -87,6 +91,17 @@ int yt_commit() {
   // Above all works like charm
   LibytProcessControl::Get().commit_grids_ = true;
   logging::LogInfo("Loading full hierarchy and local data ... done.\n");
+
+#ifdef SUPPORT_VALGRIND
+  // Dump valgrind detailed snapshot (ApJS paper purpose)
+  static int stamp = 0;
+  char valgrind[100];
+  snprintf(valgrind,
+           100,
+           "detailed_snapshot MPI%dAfterCommit%d",
+           LibytProcessControl::Get().mpi_rank_,
+           stamp);
+#endif
 
   return YT_SUCCESS;
 


### PR DESCRIPTION
## New Feature

- Dump valgrind detailed snapshot, after committing the settings -> `MPI%dAfterCommit%d`
- Provide `libyt.dump_valgrind_detailed_snapshot(filename)` method for dumping detailed snapshot at the current state during Python analysis.

## MISC
- Fix `cmake` policy version minimum in MacOS build test.
- Fix example test.
- [x] Version bump
